### PR TITLE
[FEAT] 자판기 entity 및 repository 생성 BE

### DIFF
--- a/BE/ytt/build.gradle
+++ b/BE/ytt/build.gradle
@@ -24,17 +24,21 @@ repositories {
 }
 
 dependencies {
+	// Spring Dependencies
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
-	// 하이버네이트 공간
-	implementation 'org.hibernate:hibernate-spatial:6.0.0.Final'
+	// GIS
+	implementation 'org.hibernate:hibernate-spatial:6.5.3.Final'
 	implementation 'org.locationtech.jts:jts-core:1.20.0'
+	implementation 'org.orbisgis:h2gis:2.2.3'
 
 	compileOnly 'org.projectlombok:lombok'
 

--- a/BE/ytt/build.gradle
+++ b/BE/ytt/build.gradle
@@ -25,12 +25,16 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+	// 하이버네이트 공간
+	implementation 'org.hibernate:hibernate-spatial:6.0.0.Final'
+	implementation 'org.locationtech.jts:jts-core:1.20.0'
 
 	compileOnly 'org.projectlombok:lombok'
 

--- a/BE/ytt/src/main/java/com/example/ytt/domain/model/Address.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/model/Address.java
@@ -1,0 +1,35 @@
+package com.example.ytt.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.*;
+import org.locationtech.jts.geom.Point;
+
+@Embeddable
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode(of = {"addressDetails", "location"})
+@ToString(of = {"addressDetails", "location"})
+public class Address {
+
+        @NotEmpty
+        @Column(name = "address")
+        private String addressDetails;
+
+        @NotEmpty
+        @Column(name = "location", columnDefinition = "POINT SRID 4326")
+        private Point location;
+
+        @Builder
+        public Address(String addressDetails, Point location) {
+            this.addressDetails = addressDetails;
+            this.location = location;
+        }
+
+        public void updateAddress(final String addressDetails, final Point location) {
+            this.addressDetails = addressDetails;
+            this.location = location;
+        }
+
+}

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/domain/MachineState.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/domain/MachineState.java
@@ -1,0 +1,13 @@
+package com.example.ytt.domain.vendingmachine.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum MachineState {
+    OPERATING, // 운영중
+    OUT_OF_STOCK, // 품절
+    ERROR, // 오류
+    WARNING, // 경고
+    MAINTENANCE, // 점검
+    UNKNOWN // 알수없음
+}

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/domain/VendingMachine.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/domain/VendingMachine.java
@@ -1,0 +1,57 @@
+package com.example.ytt.domain.vendingmachine.domain;
+
+import com.example.ytt.domain.model.Address;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "vending_machine")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EqualsAndHashCode(of = "id")
+@ToString(of = {"name", "address", "state", "capacity"})
+public class VendingMachine {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Embedded
+    @AttributeOverride(name = "addressDetails", column = @Column(name = "address", nullable = false))
+    @AttributeOverride(name = "location", column = @Column(name = "location", nullable = false))
+    private Address address;
+
+    @Enumerated(EnumType.STRING)
+    private MachineState state;
+
+    @Column(name = "capacity", nullable = false)
+    private Integer capacity;
+
+    @Builder
+    public VendingMachine(final String name, final Address address, final MachineState state, final Integer capacity) {
+        this.name = name;
+        this.address = address;
+        this.state = state;
+        this.capacity = capacity;
+    }
+
+    public void updateName(final String name) {
+        this.name = name;
+    }
+
+    public void updateAddress(final Address address) {
+        this.address = address;
+    }
+
+    public void updateState(final MachineState state) {
+        this.state = state;
+    }
+
+    public void updateCapacity(final Integer capacity) {
+        this.capacity = capacity;
+    }
+}

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepository.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepository.java
@@ -1,0 +1,10 @@
+package com.example.ytt.domain.vendingmachine.repository;
+
+import com.example.ytt.domain.vendingmachine.domain.VendingMachine;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface VendingMachineRepository extends JpaRepository<VendingMachine, Long> {
+    List<VendingMachine> findByNameContaining(String name);
+}

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepository.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepository.java
@@ -1,10 +1,27 @@
 package com.example.ytt.domain.vendingmachine.repository;
 
 import com.example.ytt.domain.vendingmachine.domain.VendingMachine;
+import org.locationtech.jts.geom.Point;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface VendingMachineRepository extends JpaRepository<VendingMachine, Long> {
     List<VendingMachine> findByNameContaining(String name);
+
+//    ST_DISTANCE_SPHERE 미지원으로 인해 ST_DISTANCE ST_TRANSFORM(3857, 단위를 1m로)으로 구현
+    /**
+     * 지정된 위치에서 지정된 거리 이내의 자판기 목록을 조회
+     * @param location Point(경도, 위도)
+     * @param distance 거리(단위: m)
+     * @return List
+     */
+    @Query("""
+            SELECT v
+            FROM VendingMachine v
+            WHERE ST_DISTANCE(ST_TRANSFORM(v.address.location, 3857), ST_TRANSFORM(:location, 3857)) <= :distance
+            """)
+    List<VendingMachine> findNearByLocation(@Param("location") final Point location, @Param("distance") final double distance);
 }

--- a/BE/ytt/src/main/java/com/example/ytt/global/util/GeometryUtil.java
+++ b/BE/ytt/src/main/java/com/example/ytt/global/util/GeometryUtil.java
@@ -1,0 +1,27 @@
+package com.example.ytt.global.util;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+
+/**
+ * Geometry 유틸리티 클래스
+ */
+public class GeometryUtil {
+
+    // private 생성자: 인스턴스화를 방지
+    private GeometryUtil() {
+        throw new UnsupportedOperationException("Utility Class");
+    }
+
+    /**
+     * 위도(latitude)와 경도(longitude)를 받아 Point 객체를 생성하여 반환
+     * @param latitude 위도
+     * @param longitude 경도
+     * @return Point
+     */
+    public static Point createPoint(final Double latitude, final Double longitude) {
+        final GeometryFactory geometryFactory = new GeometryFactory();
+        return geometryFactory.createPoint(new Coordinate(longitude, latitude));
+    }
+}

--- a/BE/ytt/src/main/java/com/example/ytt/global/util/GeometryUtil.java
+++ b/BE/ytt/src/main/java/com/example/ytt/global/util/GeometryUtil.java
@@ -22,6 +22,8 @@ public class GeometryUtil {
      */
     public static Point createPoint(final Double latitude, final Double longitude) {
         final GeometryFactory geometryFactory = new GeometryFactory();
-        return geometryFactory.createPoint(new Coordinate(longitude, latitude));
+        Point point = geometryFactory.createPoint(new Coordinate(longitude, latitude));
+        point.setSRID(4326);  // SRID를 4326으로 설정
+        return point;
     }
 }

--- a/BE/ytt/src/main/resources/application-local.yml
+++ b/BE/ytt/src/main/resources/application-local.yml
@@ -6,7 +6,7 @@ spring:
 
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:test   # H2 인메모리 데이터베이스를 사용
+    url: jdbc:h2:mem:test;MODE=MySQL;DATABASE_TO_LOWER=TRUE   # H2 인메모리 데이터베이스를 사용
     username: sa
     password:
 

--- a/BE/ytt/src/main/resources/application-local.yml
+++ b/BE/ytt/src/main/resources/application-local.yml
@@ -4,6 +4,12 @@ spring:
       enabled: true      # H2 콘솔을 활성화
       path: /h2-console  # H2 콘솔의 경로 설정
 
+  sql:
+    init:
+      platform: h2       # H2 데이터베이스를 사용
+      schema-locations: classpath:sql/h2gis.sql  # h2gis.sql 파일을 실행
+#      data-locations: classpath:/data.sql      # 데이터 파일 경로 설정
+
   datasource:
     driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:test;MODE=MySQL;DATABASE_TO_LOWER=TRUE   # H2 인메모리 데이터베이스를 사용
@@ -11,6 +17,7 @@ spring:
     password:
 
   jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: update  # 스키마 자동 업데이트 (create, update, validate, none)
     show-sql: true      # 쿼리 로그를 출력하도록 설정

--- a/BE/ytt/src/main/resources/sql/h2gis.sql
+++ b/BE/ytt/src/main/resources/sql/h2gis.sql
@@ -1,0 +1,4 @@
+CREATE ALIAS IF NOT EXISTS H2GIS_SPATIAL FOR
+"org.h2gis.functions.factory.H2GISFunctions.load";
+
+CALL H2GIS_SPATIAL();

--- a/BE/ytt/src/test/java/com/example/ytt/domain/model/AddressTest.java
+++ b/BE/ytt/src/test/java/com/example/ytt/domain/model/AddressTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Point;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class AddressTest {
 

--- a/BE/ytt/src/test/java/com/example/ytt/domain/model/AddressTest.java
+++ b/BE/ytt/src/test/java/com/example/ytt/domain/model/AddressTest.java
@@ -1,0 +1,64 @@
+package com.example.ytt.domain.model;
+
+import com.example.ytt.global.util.GeometryUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Point;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class AddressTest {
+
+    private Address address;
+    private Point location;
+
+    @BeforeEach
+    void setUp() {
+        location = GeometryUtil.createPoint(37.123456, 127.123456);
+
+        address = Address.builder()
+                .addressDetails("address")
+                .location(location)
+                .build();
+    }
+
+    @DisplayName("주소 생성 테스트")
+    @Test
+    void createAddress() {
+        assertThat(address.getAddressDetails()).isEqualTo("address");
+        assertThat(address.getLocation()).isEqualTo(location);
+    }
+
+    @DisplayName("주소 수정 테스트")
+    @Test
+    void updateAddress() {
+        final Point newLocation = GeometryUtil.createPoint(37.654321, 127.654321);
+        address.updateAddress("new address", newLocation);
+
+        assertThat(address.getAddressDetails()).isEqualTo("new address");
+        assertThat(address.getLocation()).isEqualTo(newLocation);
+    }
+
+    @DisplayName("Equals & HashCode 테스트")
+    @Test
+    void equalsAndHashCode() {
+        final Address newAddress = Address.builder()
+                .addressDetails("address")
+                .location(location)
+                .build();
+
+        System.out.println(address.hashCode());
+
+        assertThat(address).isEqualTo(newAddress);
+        assertThat(address.hashCode()).hasSameHashCodeAs(newAddress.hashCode());
+    }
+
+    @DisplayName("ToString 테스트")
+    @Test
+    void toStringTest() {
+        System.out.println(address.toString());
+
+        assertThat(address.toString()).contains("addressDetails", "location");
+    }
+}

--- a/BE/ytt/src/test/java/com/example/ytt/domain/vendingmachine/domain/VendingMachineTest.java
+++ b/BE/ytt/src/test/java/com/example/ytt/domain/vendingmachine/domain/VendingMachineTest.java
@@ -1,0 +1,94 @@
+package com.example.ytt.domain.vendingmachine.domain;
+
+import com.example.ytt.domain.model.Address;
+import com.example.ytt.global.util.GeometryUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class VendingMachineTest {
+
+    private VendingMachine vendingMachine;
+    private Address address;
+
+    @BeforeEach
+    void setUp() {
+         address = Address.builder()
+                .addressDetails("address")
+                .location(GeometryUtil.createPoint(37.123456, 127.123456))
+                .build();
+
+        vendingMachine = VendingMachine.builder()
+                .name("name")
+                .address(address)
+                .state(MachineState.OPERATING)
+                .capacity(10)
+                .build();
+    }
+
+    @DisplayName("자판기 생성 테스트")
+    @Test
+    void createVendingMachine() {
+        assertThat(vendingMachine).isNotNull();
+        assertThat(vendingMachine.getName()).isEqualTo("name");
+        assertThat(vendingMachine.getAddress()).isEqualTo(address);
+        assertThat(vendingMachine.getState()).isEqualTo(MachineState.OPERATING);
+        assertThat(vendingMachine.getCapacity()).isEqualTo(10);
+    }
+
+    @DisplayName("자판기 이름 수정 테스트")
+    @Test
+    void updateVendingMachineName() {
+        vendingMachine.updateName("new name");
+
+        assertThat(vendingMachine.getName()).isEqualTo("new name");
+    }
+
+    @DisplayName("자판기 주소 수정 테스트")
+    @Test
+    void updateVendingMachineAddress() {
+        final Address newAddress = Address.builder()
+                .addressDetails("new address")
+                .location(GeometryUtil.createPoint(37.654321, 127.654321))
+                .build();
+
+        vendingMachine.updateAddress(newAddress);
+
+        assertThat(vendingMachine.getAddress()).isEqualTo(newAddress);
+    }
+
+    @DisplayName("자판기 상태 수정 테스트")
+    @Test
+    void updateVendingMachineState() {
+        vendingMachine.updateState(MachineState.MAINTENANCE);
+
+        assertThat(vendingMachine.getState()).isEqualTo(MachineState.MAINTENANCE);
+    }
+
+    @DisplayName("Equals & HashCode 테스트")
+    @Test
+    void equalsAndHashCode() {
+        final VendingMachine vendingMachine2 = VendingMachine.builder()
+                .name("name")
+                .address(address)
+                .state(MachineState.OPERATING)
+                .capacity(10)
+                .build();
+
+        System.out.println(vendingMachine.hashCode());
+
+        assertThat(vendingMachine).isEqualTo(vendingMachine2);
+        assertThat(vendingMachine.hashCode()).hasSameHashCodeAs(vendingMachine2.hashCode());
+    }
+
+    @DisplayName("ToString 테스트")
+    @Test
+    void toStringTest() {
+        System.out.println(vendingMachine.toString());
+
+        assertThat(vendingMachine.toString()).contains("name", "address", "state", "capacity");
+    }
+
+}

--- a/BE/ytt/src/test/java/com/example/ytt/domain/vendingmachine/domain/VendingMachineTest.java
+++ b/BE/ytt/src/test/java/com/example/ytt/domain/vendingmachine/domain/VendingMachineTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class VendingMachineTest {
 

--- a/BE/ytt/src/test/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryTest.java
+++ b/BE/ytt/src/test/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryTest.java
@@ -1,0 +1,72 @@
+package com.example.ytt.domain.vendingmachine.repository;
+
+import com.example.ytt.domain.model.Address;
+import com.example.ytt.domain.vendingmachine.domain.MachineState;
+import com.example.ytt.domain.vendingmachine.domain.VendingMachine;
+import com.example.ytt.global.util.GeometryUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DataJpaTest
+class VendingMachineRepositoryTest {
+
+    @Autowired
+    private VendingMachineRepository vendingMachineRepository;
+
+    private VendingMachine sevedVendingMachine;
+    private Address address;
+    
+    @BeforeEach
+    void setUp() {
+        address = Address.builder()
+                .addressDetails("address")
+                .location(GeometryUtil.createPoint(37.123456, 127.123456))
+                .build();
+
+        sevedVendingMachine = vendingMachineRepository.save(VendingMachine.builder()
+                .name("vendingMachine")
+                .address(address)
+                .state(MachineState.OPERATING)
+                .capacity(10)
+                .build());
+    }
+
+    @DisplayName("자판기 생성 테스트")
+    @Test
+    void createVendingMachine() {
+        assertThat(sevedVendingMachine).isNotNull();
+        assertThat(sevedVendingMachine.getName()).isEqualTo("vendingMachine");
+        assertThat(sevedVendingMachine.getAddress()).isEqualTo(address);
+        assertThat(sevedVendingMachine.getState()).isEqualTo(MachineState.OPERATING);
+        assertThat(sevedVendingMachine.getCapacity()).isEqualTo(10);
+    }
+
+    @DisplayName("자판기 생성 테스트2")
+    @Test
+    void createVendingMachine2() {
+        final VendingMachine vendingMachine = vendingMachineRepository.findById(sevedVendingMachine.getId()).orElse(null);
+
+        assertThat(vendingMachine).isNotNull();
+        assertThat(vendingMachine.getName()).isEqualTo("vendingMachine");
+        assertThat(vendingMachine.getAddress()).isEqualTo(address);
+        assertThat(vendingMachine.getState()).isEqualTo(MachineState.OPERATING);
+        assertThat(vendingMachine.getCapacity()).isEqualTo(10);
+    }
+
+    @DisplayName("자판기 이름으로 찾기 테스트")
+    @Test
+    void findByNameContaining() {
+        final List<VendingMachine> vendingMachine = vendingMachineRepository.findByNameContaining("vending");
+
+        assertThat(vendingMachine).isNotNull();
+        assertThat(vendingMachine.get(0).getName()).contains("vending");
+    }
+
+}

--- a/BE/ytt/src/test/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryTest.java
+++ b/BE/ytt/src/test/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryTest.java
@@ -12,7 +12,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.List;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 class VendingMachineRepositoryTest {
@@ -22,7 +22,7 @@ class VendingMachineRepositoryTest {
 
     private VendingMachine sevedVendingMachine;
     private Address address;
-    
+
     @BeforeEach
     void setUp() {
         address = Address.builder()


### PR DESCRIPTION
## PR Type
<!-- PR 전 해당사항에 'x' 표시 ex) - [x] 기능 개발 -->
- [x] 기능 개발
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타: 

## 요약
자판기 entity 및 repository 생성 

## 상세 내용
- 자판기 entity
  - VendingMachine(자판기) 객체와 Adress 임베디드 객체 생성
- RDBMS, JPA의 공간 데이터, 공간 함수 활성화
- 자판기 repository
  - 자판기 이름 기반 조회 
  - 주변 자판기 리스트 조회 (입력한 좌표에서 특정 거리 이내의 자판기 조회)

## Issue Number
<!-- 연관된 이슈는 #넘버, 해결된 이슈는 resolved #넘버 -->
resolved #13
