### PR TITLE
[FEAT] 약 entity 생성

### DIFF
--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/domain/Ingredient.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/domain/Ingredient.java
@@ -1,0 +1,41 @@
+package com.example.ytt.domain.medicine.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.util.Assert;
+
+@Entity
+@Getter
+@Table(name = "ingredient")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = {"id", "name"})
+@ToString(of = {"name"})
+public class Ingredient {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ingredient_id", nullable = false)
+    private Long id;
+
+    @Column(name = "ingredient_name", nullable = false)
+    private String name; // 성분명
+
+    @Column(name = "efficacy", nullable = false)
+    private String efficacy; // 효능
+
+    @Builder
+    public Ingredient(final String name, final String efficacy) {
+        Assert.hasText(name, "성분명은 필수입니다.");
+        Assert.hasText(efficacy, "효능은 필수입니다.");
+
+        this.name = name;
+        this.efficacy = efficacy;
+    }
+
+    public static Ingredient of(final String name, final String efficacy) {
+        return Ingredient.builder()
+                .name(name)
+                .efficacy(efficacy)
+                .build();
+    }
+}

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/domain/Ingredient.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/domain/Ingredient.java
@@ -20,16 +20,21 @@ public class Ingredient {
     @Column(name = "ingredient_name", nullable = false)
     private String name; // 성분명
 
-    @Column(name = "efficacy", nullable = false)
+    @Setter
+    @Column(name = "efficacy", columnDefinition = "TEXT")
     private String efficacy; // 효능
 
     @Builder
     public Ingredient(final String name, final String efficacy) {
         Assert.hasText(name, "성분명은 필수입니다.");
-        Assert.hasText(efficacy, "효능은 필수입니다.");
+//        Assert.hasText(efficacy, "효능은 필수입니다.");
 
         this.name = name;
         this.efficacy = efficacy;
+    }
+
+    public static Ingredient of(final String name) {
+        return of(name, null);
     }
 
     public static Ingredient of(final String name, final String efficacy) {

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/domain/Medicine.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/domain/Medicine.java
@@ -15,93 +15,78 @@ import java.util.List;
 @ToString(of = {"id", "name", "productCode", "manufacturer"})
 public class Medicine {
 
-    // TODO: e약은요 API, 의약품 제품 허가정보 중 기준 정할 것 (현재는 e약은요 API 기준)
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "medicine_id", nullable = false)
     private Long id;
 
     @Column(name = "name", nullable = false)
-    private String name;                                                                // 제품명
+    private String name;
 
     @Column(name = "product_code", nullable = false)
-    private String productCode;                                                         // 품목기준코드
+    private String productCode;
 
     @Column(name = "manufacturer", nullable = false)
-    private String manufacturer;                                                        // 제조사
+    private String manufacturer;
 
+    // EE, Efficacy and Effect (효능효과)
     @Column(name = "efficacy", columnDefinition = "TEXT", nullable = false)
-    private String efficacy;                                                            // 효능 (이 약의 효능은 무엇입니까?) or 효능효과
+    private String efficacy;
 
-    @Column(name = "usage_instructions", columnDefinition = "TEXT", nullable = false)
-    private String usageInstructions;                                                   // 사용법 (이 약은 어떻게 사용합니까?) or 용법용량
+    // UD, Usage and Dosage (용법용량)
+    @Column(name = "usage", columnDefinition = "TEXT", nullable = false)
+    private String usage;
 
-    @Column(name = "warnings", columnDefinition = "TEXT")
-    private String warnings;                                                            // 주의사항 경고 (이 약을 사용하기 전에 반드시 알아야 할 내용은 무엇입니까?)
-
+    // NB, Nota Bene (주의사항)
     @Column(name = "precautions", columnDefinition = "TEXT", nullable = false)
-    private String precautions;                                                         // 주의사항 (이 약의 사용상 주의사항은 무엇입니까?) or 사용상의 주의사항
+    private String precautions;
 
-    @Column(name = "interactions", columnDefinition = "TEXT")
-    private String interactions;                                                        // 상호작용 (이 약을 사용하는 동안 주의해야 할 약 또는 음식은 무엇입니까?)
-
-    @Column(name = "side_effects", columnDefinition = "TEXT", nullable = false)
-    private String sideEffects;                                                         // 부작용 (이 약은 어떤 이상반응이 나타날 수 있습니까?)
-
-    @Column(name = "storage_instructions", columnDefinition = "TEXT")
-    private String storageInstructions;                                                 // 보관법 (이 약은 어떻게 보관해야 합니까?)
-
-//    @Column(name = "expiration_date", nullable = false)
-//    private String expirationDate;                                                     // 유효기간, e약은요 API에 정보 없음, 의약품 제품 허가정보에는 있음
-
-    @Column(name = "price", nullable = false)
-    private Integer price;                                                              // 가격
+    // 유효기간
+    @Column(name = "validity_period", nullable = false)
+    private String validityPeriod;
 
     @Column(name = "image_url")
-    private String imageUrl;                                                               // 이미지
+    private String imageURL;
 
+    @Column(name = "price", nullable = false)
+    private int price;
+
+    @Setter
     @OneToMany(mappedBy = "medicine", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<MedicineIngredient> ingredients;
+    private List<MedicineIngredient> ingredients = new ArrayList<>();                   // 성분
 
     @Builder
-    public Medicine(String name, String productCode, String manufacturer, String efficacy, String usageInstructions, String warnings, String precautions, String interactions, String sideEffects, String storageInstructions, Integer price, String imageUrl, List<MedicineIngredient> ingredients) {
-        Assert.hasText(name, "약 이름은 필수입니다.");
-        Assert.hasText(productCode, "약 코드는 필수입니다.");
+    public Medicine(final String name, final String productCode, final String manufacturer, final String efficacy, final String usage, final String precautions, final String validityPeriod, final String imageURL, final int price) {
+        Assert.hasText(name, "약품명은 필수입니다.");
+        Assert.hasText(productCode, "제품코드는 필수입니다.");
         Assert.hasText(manufacturer, "제조사는 필수입니다.");
-        Assert.hasText(efficacy, "효능은 필수입니다.");
-        Assert.hasText(usageInstructions, "사용법은 필수입니다.");
+        Assert.hasText(efficacy, "효능효과는 필수입니다.");
+        Assert.hasText(usage, "용법용량은 필수입니다.");
         Assert.hasText(precautions, "주의사항은 필수입니다.");
-        Assert.hasText(sideEffects, "부작용은 필수입니다.");
-        Assert.notNull(price, "가격은 필수입니다.");
-
-//        Assert.notNull(warnings, "주의사항 경고는 필수입니다.");
-//        Assert.notNull(interactions, "상호작용은 필수입니다.");
-//        Assert.notNull(storageInstructions, "보관법은 필수입니다.");
-//        Assert.notNull(imageUrl, "이미지는 필수입니다.");
-//        Assert.notNull(ingredients, "성분은 필수입니다.");
+        Assert.hasText(validityPeriod, "유효기간은 필수입니다.");
+        Assert.isTrue(price > 0, "가격은 0보다 커야합니다.");
 
         this.name = name;
         this.productCode = productCode;
         this.manufacturer = manufacturer;
         this.efficacy = efficacy;
-        this.usageInstructions = usageInstructions;
-        this.warnings = warnings;
+        this.usage = usage;
         this.precautions = precautions;
-        this.interactions = interactions;
-        this.sideEffects = sideEffects;
-        this.storageInstructions = storageInstructions;
+        this.validityPeriod = validityPeriod;
+        this.imageURL = imageURL;
         this.price = price;
-        this.imageUrl = imageUrl;
-        this.ingredients = ingredients == null ? new ArrayList<>() : ingredients;
     }
 
-    public void addIngredient(Ingredient ingredient) {
-        addIngredient(ingredient, 1);
+    public void addIngredient(Ingredient ingredient, int quantity, String unit, String pharmacopeia) {
+        addIngredient(MedicineIngredient.of(this, ingredient, quantity, unit, pharmacopeia));
     }
 
-    public void addIngredient(Ingredient ingredient, Integer quantity) {
-        this.ingredients.add(MedicineIngredient.of(this, ingredient, quantity));
+    public void addIngredient(Ingredient ingredient, int quantity, Unit unit, Pharmacopeia pharmacopeia) {
+        addIngredient(MedicineIngredient.of(this, ingredient, quantity, unit, pharmacopeia));
+    }
+
+    public void addIngredient(MedicineIngredient medicineIngredient) {
+        ingredients.add(medicineIngredient);
     }
 
     public void removeIngredient(Ingredient ingredient) {

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/domain/Medicine.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/domain/Medicine.java
@@ -1,0 +1,110 @@
+package com.example.ytt.domain.medicine.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.util.Assert;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "medicine")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = {"id", "productCode"})
+@ToString(of = {"id", "name", "productCode", "manufacturer"})
+public class Medicine {
+
+    // TODO: e약은요 API, 의약품 제품 허가정보 중 기준 정할 것 (현재는 e약은요 API 기준)
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "medicine_id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;                                                                // 제품명
+
+    @Column(name = "product_code", nullable = false)
+    private String productCode;                                                         // 품목기준코드
+
+    @Column(name = "manufacturer", nullable = false)
+    private String manufacturer;                                                        // 제조사
+
+    @Column(name = "efficacy", columnDefinition = "TEXT", nullable = false)
+    private String efficacy;                                                            // 효능 (이 약의 효능은 무엇입니까?) or 효능효과
+
+    @Column(name = "usage_instructions", columnDefinition = "TEXT", nullable = false)
+    private String usageInstructions;                                                   // 사용법 (이 약은 어떻게 사용합니까?) or 용법용량
+
+    @Column(name = "warnings", columnDefinition = "TEXT")
+    private String warnings;                                                            // 주의사항 경고 (이 약을 사용하기 전에 반드시 알아야 할 내용은 무엇입니까?)
+
+    @Column(name = "precautions", columnDefinition = "TEXT", nullable = false)
+    private String precautions;                                                         // 주의사항 (이 약의 사용상 주의사항은 무엇입니까?) or 사용상의 주의사항
+
+    @Column(name = "interactions", columnDefinition = "TEXT")
+    private String interactions;                                                        // 상호작용 (이 약을 사용하는 동안 주의해야 할 약 또는 음식은 무엇입니까?)
+
+    @Column(name = "side_effects", columnDefinition = "TEXT", nullable = false)
+    private String sideEffects;                                                         // 부작용 (이 약은 어떤 이상반응이 나타날 수 있습니까?)
+
+    @Column(name = "storage_instructions", columnDefinition = "TEXT")
+    private String storageInstructions;                                                 // 보관법 (이 약은 어떻게 보관해야 합니까?)
+
+//    @Column(name = "expiration_date", nullable = false)
+//    private String expirationDate;                                                     // 유효기간, e약은요 API에 정보 없음, 의약품 제품 허가정보에는 있음
+
+    @Column(name = "price", nullable = false)
+    private Integer price;                                                              // 가격
+
+    @Column(name = "image_url")
+    private String imageUrl;                                                               // 이미지
+
+    @OneToMany(mappedBy = "medicine", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<MedicineIngredient> ingredients;
+
+    @Builder
+    public Medicine(String name, String productCode, String manufacturer, String efficacy, String usageInstructions, String warnings, String precautions, String interactions, String sideEffects, String storageInstructions, Integer price, String imageUrl, List<MedicineIngredient> ingredients) {
+        Assert.hasText(name, "약 이름은 필수입니다.");
+        Assert.hasText(productCode, "약 코드는 필수입니다.");
+        Assert.hasText(manufacturer, "제조사는 필수입니다.");
+        Assert.hasText(efficacy, "효능은 필수입니다.");
+        Assert.hasText(usageInstructions, "사용법은 필수입니다.");
+        Assert.hasText(precautions, "주의사항은 필수입니다.");
+        Assert.hasText(sideEffects, "부작용은 필수입니다.");
+        Assert.notNull(price, "가격은 필수입니다.");
+
+//        Assert.notNull(warnings, "주의사항 경고는 필수입니다.");
+//        Assert.notNull(interactions, "상호작용은 필수입니다.");
+//        Assert.notNull(storageInstructions, "보관법은 필수입니다.");
+//        Assert.notNull(imageUrl, "이미지는 필수입니다.");
+//        Assert.notNull(ingredients, "성분은 필수입니다.");
+
+        this.name = name;
+        this.productCode = productCode;
+        this.manufacturer = manufacturer;
+        this.efficacy = efficacy;
+        this.usageInstructions = usageInstructions;
+        this.warnings = warnings;
+        this.precautions = precautions;
+        this.interactions = interactions;
+        this.sideEffects = sideEffects;
+        this.storageInstructions = storageInstructions;
+        this.price = price;
+        this.imageUrl = imageUrl;
+        this.ingredients = ingredients == null ? new ArrayList<>() : ingredients;
+    }
+
+    public void addIngredient(Ingredient ingredient) {
+        addIngredient(ingredient, 1);
+    }
+
+    public void addIngredient(Ingredient ingredient, Integer quantity) {
+        this.ingredients.add(MedicineIngredient.of(this, ingredient, quantity));
+    }
+
+    public void removeIngredient(Ingredient ingredient) {
+        this.ingredients.removeIf(medicineIngredient -> medicineIngredient.getIngredient().equals(ingredient));
+    }
+}

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/domain/MedicineIngredient.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/domain/MedicineIngredient.java
@@ -1,0 +1,52 @@
+package com.example.ytt.domain.medicine.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+@Entity
+@Getter
+@Table(name = "medicine_ingredient")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MedicineIngredient {
+
+    // TODO: 복합키를 사용하는 것도 고려해볼 것
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "medicine_ingredient_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "medicine_id", nullable = false)
+    private Medicine medicine;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ingredient_id", nullable = false)
+    private Ingredient ingredient;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Builder
+    public MedicineIngredient(final Medicine medicine, final Ingredient ingredient, final Integer quantity) {
+        Assert.notNull(medicine, "약은 필수입니다.");
+        Assert.notNull(ingredient, "성분은 필수입니다.");
+        Assert.notNull(quantity, "수량은 필수입니다.");
+
+        this.medicine = medicine;
+        this.ingredient = ingredient;
+        this.quantity = quantity;
+    }
+
+    public static MedicineIngredient of(final Medicine medicine, final Ingredient ingredient, final Integer quantity) {
+        return MedicineIngredient.builder()
+                .medicine(medicine)
+                .ingredient(ingredient)
+                .quantity(quantity)
+                .build();
+    }
+}

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/domain/MedicineIngredient.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/domain/MedicineIngredient.java
@@ -13,8 +13,6 @@ import org.springframework.util.Assert;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MedicineIngredient {
 
-    // TODO: 복합키를 사용하는 것도 고려해볼 것
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "medicine_ingredient_id", nullable = false)
@@ -29,24 +27,40 @@ public class MedicineIngredient {
     private Ingredient ingredient;
 
     @Column(name = "quantity", nullable = false)
-    private Integer quantity;
+    private int quantity;
+
+    @Enumerated(EnumType.STRING)
+    private Unit unit;
+
+    @Enumerated(EnumType.STRING)
+    private Pharmacopeia pharmacopeia;
 
     @Builder
-    public MedicineIngredient(final Medicine medicine, final Ingredient ingredient, final Integer quantity) {
+    public MedicineIngredient(final Medicine medicine, final Ingredient ingredient, final int quantity, final Unit unit, final Pharmacopeia pharmacopeia) {
         Assert.notNull(medicine, "약은 필수입니다.");
         Assert.notNull(ingredient, "성분은 필수입니다.");
-        Assert.notNull(quantity, "수량은 필수입니다.");
+        Assert.isTrue(quantity > 0, "수량은 0보다 커야합니다.");
+        Assert.notNull(unit, "단위는 필수입니다.");
+        Assert.notNull(pharmacopeia, "약전은 필수입니다.");
 
         this.medicine = medicine;
         this.ingredient = ingredient;
         this.quantity = quantity;
+        this.unit = unit;
+        this.pharmacopeia = pharmacopeia;
     }
 
-    public static MedicineIngredient of(final Medicine medicine, final Ingredient ingredient, final Integer quantity) {
+    public static MedicineIngredient of(final Medicine medicine, final Ingredient ingredient, final int quantity, final Unit unit, final Pharmacopeia pharmacopeia) {
         return MedicineIngredient.builder()
                 .medicine(medicine)
                 .ingredient(ingredient)
                 .quantity(quantity)
+                .unit(unit)
+                .pharmacopeia(pharmacopeia)
                 .build();
+    }
+
+    public static MedicineIngredient of(final Medicine medicine, final Ingredient ingredient, final int quantity, final String unit, final String pharmacopeia) {
+        return of(medicine, ingredient, quantity, Unit.from(unit), Pharmacopeia.from(pharmacopeia));
     }
 }

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/domain/Pharmacopeia.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/domain/Pharmacopeia.java
@@ -1,0 +1,33 @@
+package com.example.ytt.domain.medicine.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Pharmacopeia {
+    KP("KP"),
+    KPC("KPC"),
+    KHP("KHP"),
+    USP("USP"),
+    JP("JP"),
+    EP("EP"),
+    BP("BP"),
+    DAB("DAB"),
+    PF("PF");
+
+    private final String info;
+
+    public static Pharmacopeia from(String info) {
+        for (Pharmacopeia pharmacopeia : Pharmacopeia.values()) {
+            if (pharmacopeia.info.equals(info)) {
+                return pharmacopeia;
+            }
+        }
+
+        return KP; // Default unit is KP, 나중에 예외처리
+    }
+
+}
+
+

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/domain/Unit.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/domain/Unit.java
@@ -1,0 +1,26 @@
+package com.example.ytt.domain.medicine.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Unit {
+    MG("mg"),
+    G("g"),
+    ML("ml"),
+    L("l"),
+    EA("개");
+
+    private final String info;
+
+    public static Unit from(String unit) {
+        for (Unit u : Unit.values()) {
+            if (u.info.equals(unit)) {
+                return u;
+            }
+        }
+
+        return G; // Default unit is G, 나중에 예외처리
+    }
+}

--- a/BE/ytt/src/main/java/com/example/ytt/domain/model/Address.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/model/Address.java
@@ -32,11 +32,11 @@ public class Address {
             this.location = location;
         }
 
-        public static Address from(String addressDetails, double latitude, double longitude) {
-            return from(addressDetails, GeometryUtil.createPoint(latitude, longitude));
+        public static Address of(String addressDetails, double latitude, double longitude) {
+            return of(addressDetails, GeometryUtil.createPoint(latitude, longitude));
         }
 
-        public static Address from(String addressDetails, Point location) {
+        public static Address of(String addressDetails, Point location) {
             return Address.builder()
                     .addressDetails(addressDetails)
                     .location(location)

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/domain/VendingMachine.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/domain/VendingMachine.java
@@ -30,14 +30,14 @@ public class VendingMachine {
     private MachineState state;
 
     @Column(name = "capacity", nullable = false)
-    private Integer capacity;
+    private int capacity;
 
     @Builder
     public VendingMachine(final String name, final Address address, final MachineState state, final Integer capacity) {
         Assert.hasText(name, "자판기 이름은 필수입니다.");
         Assert.notNull(address, "자판기 주소는 필수입니다.");
         Assert.notNull(state, "자판기 상태는 필수입니다.");
-        Assert.notNull(capacity, "자판기 용량은 필수입니다.");
+        Assert.isTrue(capacity > 0, "자판기 용량은 0보다 커야합니다.");
 
         this.name = name;
         this.address = address;
@@ -57,7 +57,7 @@ public class VendingMachine {
         this.state = state;
     }
 
-    public void updateCapacity(final Integer capacity) {
+    public void updateCapacity(final int capacity) {
         this.capacity = capacity;
     }
 }

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/dto/VendingMachineDetailDto.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/dto/VendingMachineDetailDto.java
@@ -16,15 +16,15 @@ public record VendingMachineDetailDto(
         @Schema(description = "자판기 용량", example = "3")                    Integer capacity,
         @Schema(description = "즐겨찾기 여부", example = "true")               Boolean isFavorite
 ) {
-    public static VendingMachineDetailDto from(Long id, String name, MachineState state, String address, Double latitude, Double longitude, Integer capacity, Boolean isFavorite) {
+    public static VendingMachineDetailDto of(Long id, String name, MachineState state, String address, Double latitude, Double longitude, Integer capacity, Boolean isFavorite) {
         return new VendingMachineDetailDto(id, name, state, address, latitude, longitude, capacity, isFavorite);
     }
 
-    public static VendingMachineDetailDto from(Long id, String name, MachineState state, Address address, Integer capacity, Boolean isFavorite) {
+    public static VendingMachineDetailDto of(Long id, String name, MachineState state, Address address, Integer capacity, Boolean isFavorite) {
         return new VendingMachineDetailDto(id, name, state, address.getAddressDetails(), address.getLocation().getY(), address.getLocation().getX(), capacity, isFavorite);
     }
 
-    public static VendingMachineDetailDto from(VendingMachine vendingMachine, Boolean isFavorite) {
-        return from(vendingMachine.getId(), vendingMachine.getName(), vendingMachine.getState(), vendingMachine.getAddress(), vendingMachine.getCapacity(), isFavorite);
+    public static VendingMachineDetailDto of(VendingMachine vendingMachine, Boolean isFavorite) {
+        return of(vendingMachine.getId(), vendingMachine.getName(), vendingMachine.getState(), vendingMachine.getAddress(), vendingMachine.getCapacity(), isFavorite);
     }
 }

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/dto/VendingMachineDetailDto.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/dto/VendingMachineDetailDto.java
@@ -7,24 +7,28 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(title = "자판기 상세 Respone DTO", description = "자판기 상세 정보를 담은 DTO")
 public record VendingMachineDetailDto(
-        @Schema(description = "자판기 ID", example = "1")                      Long id,
-        @Schema(description = "자판기 이름", example = "강릉원주대 자판기")    String name,
-        @Schema(description = "자판기 상태", example = "OPERATING")            MachineState state,
-        @Schema(description = "자판기 주소", example = "남원로 150")           String address,
-        @Schema(description = "자판기 위도", example = "37.305121")            Double latitude,
-        @Schema(description = "자판기 경도", example = "127.922653")           Double longitude,
-        @Schema(description = "자판기 용량", example = "3")                    Integer capacity,
-        @Schema(description = "즐겨찾기 여부", example = "true")               Boolean isFavorite
+        @Schema(description = "자판기 ID")     Long id,
+        @Schema(description = "자판기 이름")    String name,
+        @Schema(description = "자판기 상태")    MachineState state,
+        @Schema(description = "자판기 주소")    String address,
+        @Schema(description = "자판기 위도")    double latitude,
+        @Schema(description = "자판기 경도")    double longitude,
+        @Schema(description = "자판기 용량")    int capacity,
+        @Schema(description = "즐겨찾기 여부")   boolean isFavorite
 ) {
-    public static VendingMachineDetailDto of(Long id, String name, MachineState state, String address, Double latitude, Double longitude, Integer capacity, Boolean isFavorite) {
+    public static VendingMachineDetailDto of(Long id, String name, MachineState state, String address, double latitude, double longitude, int capacity, boolean isFavorite) {
         return new VendingMachineDetailDto(id, name, state, address, latitude, longitude, capacity, isFavorite);
     }
 
-    public static VendingMachineDetailDto of(Long id, String name, MachineState state, Address address, Integer capacity, Boolean isFavorite) {
+    public static VendingMachineDetailDto of(Long id, String name, MachineState state, Address address, int capacity, boolean isFavorite) {
         return new VendingMachineDetailDto(id, name, state, address.getAddressDetails(), address.getLocation().getY(), address.getLocation().getX(), capacity, isFavorite);
     }
 
     public static VendingMachineDetailDto of(VendingMachine vendingMachine, Boolean isFavorite) {
         return of(vendingMachine.getId(), vendingMachine.getName(), vendingMachine.getState(), vendingMachine.getAddress(), vendingMachine.getCapacity(), isFavorite);
+    }
+
+    public static VendingMachineDetailDto from(VendingMachine vendingMachine) {
+        return of(vendingMachine, false);
     }
 }

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/dto/VendingMachineDto.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/dto/VendingMachineDto.java
@@ -14,17 +14,17 @@ public record VendingMachineDto(
         @Schema(description = "자판기 위도", example = "37.305121")           Double latitude,
         @Schema(description = "자판기 경도", example = "127.922653")          Double longitude
 ) {
-    public static VendingMachineDto from(Long id, String name, MachineState state, String address, Double latitude, Double longitude) {
+    public static VendingMachineDto of(Long id, String name, MachineState state, String address, Double latitude, Double longitude) {
         return new VendingMachineDto(id, name, state, address, latitude, longitude);
     }
 
     // Point(address.getLocation)는 경도, 위도 순이라 getY(), getX() 순서로 작성
-    public static VendingMachineDto from(Long id, String name, MachineState state, Address address) {
+    public static VendingMachineDto of(Long id, String name, MachineState state, Address address) {
         return new VendingMachineDto(id, name, state, address.getAddressDetails(), address.getLocation().getY(), address.getLocation().getX());
     }
 
     public static VendingMachineDto from(VendingMachine vendingMachine) {
-        return from(vendingMachine.getId(), vendingMachine.getName(), vendingMachine.getState(), vendingMachine.getAddress());
+        return of(vendingMachine.getId(), vendingMachine.getName(), vendingMachine.getState(), vendingMachine.getAddress());
     }
 
 }

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/dto/VendingMachineDto.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/dto/VendingMachineDto.java
@@ -7,12 +7,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(title = "자판기 Respone DTO", description = "자판기 정보를 담은 DTO")
 public record VendingMachineDto(
-        @Schema(description = "자판기 식별자", example = "1")                 Long id,
-        @Schema(description = "자판기 이름", example = "강릉원주대 자판기")   String name,
-        @Schema(description = "자판기 상태", example = "OPERATING")           MachineState state,
-        @Schema(description = "자판기 주소", example = "남원로 150")          String address,
-        @Schema(description = "자판기 위도", example = "37.305121")           Double latitude,
-        @Schema(description = "자판기 경도", example = "127.922653")          Double longitude
+        @Schema(description = "자판기 ID")     Long id,
+        @Schema(description = "자판기 이름")    String name,
+        @Schema(description = "자판기 상태")    MachineState state,
+        @Schema(description = "자판기 주소")    String address,
+        @Schema(description = "자판기 위도")    double latitude,
+        @Schema(description = "자판기 경도")    double longitude
 ) {
     public static VendingMachineDto of(Long id, String name, MachineState state, String address, Double latitude, Double longitude) {
         return new VendingMachineDto(id, name, state, address, latitude, longitude);

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/service/VendingMachineFindService.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/service/VendingMachineFindService.java
@@ -52,7 +52,7 @@ public class VendingMachineFindService {
         // TODO: 즐겨찾기 여부 확인 로직 필요
         boolean isFavorite = false;
 
-        return VendingMachineDetailDto.from(vendingMachine, isFavorite);
+        return VendingMachineDetailDto.of(vendingMachine, isFavorite);
     }
 
 }

--- a/BE/ytt/src/test/java/com/example/ytt/domain/medicine/domain/IngredientTest.java
+++ b/BE/ytt/src/test/java/com/example/ytt/domain/medicine/domain/IngredientTest.java
@@ -1,0 +1,26 @@
+package com.example.ytt.domain.medicine.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IngredientTest {
+
+    private Ingredient ingredient;
+
+    @BeforeEach
+    void setUp() {
+        ingredient = Ingredient.of("ingredient", "efficacy");
+    }
+
+    @DisplayName("성분 생성 테스트")
+    @Test
+    void createIngredient() {
+        assertThat(ingredient).isNotNull();
+        assertThat(ingredient.getName()).isEqualTo("ingredient");
+        assertThat(ingredient.getEfficacy()).isEqualTo("efficacy");
+    }
+
+}

--- a/BE/ytt/src/test/java/com/example/ytt/domain/medicine/domain/MedicineTest.java
+++ b/BE/ytt/src/test/java/com/example/ytt/domain/medicine/domain/MedicineTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MedicineTest {
@@ -17,11 +19,16 @@ class MedicineTest {
                 .productCode("productCode")
                 .manufacturer("manufacturer")
                 .efficacy("efficacy")
-                .usageInstructions("usageInstructions")
+                .usage("usage")
                 .precautions("precautions")
-                .sideEffects("sideEffects")
+                .validityPeriod("validityPeriod")
+                .imageURL("imageURL")
                 .price(1000)
                 .build();
+
+        medicine.addIngredient(Ingredient.of("ingredient1"), 1, Unit.MG, Pharmacopeia.KP);
+        medicine.addIngredient(Ingredient.of("ingredient2"), 1, Unit.G, Pharmacopeia.KHP);
+        medicine.addIngredient(Ingredient.of("ingredient3"), 1, Unit.G, Pharmacopeia.KHP);
     }
 
     @DisplayName("약 생성 테스트")
@@ -32,23 +39,32 @@ class MedicineTest {
         assertThat(medicine.getProductCode()).isEqualTo("productCode");
         assertThat(medicine.getManufacturer()).isEqualTo("manufacturer");
         assertThat(medicine.getEfficacy()).isEqualTo("efficacy");
-        assertThat(medicine.getUsageInstructions()).isEqualTo("usageInstructions");
+        assertThat(medicine.getUsage()).isEqualTo("usage");
         assertThat(medicine.getPrecautions()).isEqualTo("precautions");
-        assertThat(medicine.getSideEffects()).isEqualTo("sideEffects");
+        assertThat(medicine.getValidityPeriod()).isEqualTo("validityPeriod");
+        assertThat(medicine.getImageURL()).isEqualTo("imageURL");
         assertThat(medicine.getPrice()).isEqualTo(1000);
+
+        final List<MedicineIngredient> ingredients = medicine.getIngredients();
+
+        assertThat(ingredients).hasSize(3);
+        assertThat(ingredients)
+                .extracting(MedicineIngredient::getIngredient)
+                .extracting(Ingredient::getName)
+                .containsExactly("ingredient1", "ingredient2", "ingredient3");
     }
 
     @DisplayName("성분 추가")
     @Test
     void addIngredient() {
-        final Ingredient ingredient = Ingredient.of("ingredient", "efficacy");
+        final Ingredient ingredient = Ingredient.of("ingredient4", "efficacy");
 
-        medicine.addIngredient(ingredient);
-        medicine.addIngredient(ingredient);
-        medicine.addIngredient(ingredient);
+        medicine.addIngredient(ingredient, 1, "mg", "KP");
+        medicine.addIngredient(ingredient, 2, "mg", "KP");
+        medicine.addIngredient(ingredient, 3, "mg", "KP");
 
         assertThat(medicine.getIngredients())
-                .hasSize(3)
+                .hasSize(6)
                 .extracting(v -> v.getIngredient().equals(ingredient))
                 .isNotNull();
     }
@@ -56,13 +72,13 @@ class MedicineTest {
     @DisplayName("성분 삭제")
     @Test
     void removeIngredient() {
-        final Ingredient ingredient = Ingredient.of("ingredient", "efficacy");
+        final Ingredient ingredient = Ingredient.of("ingredient4", "efficacy");
 
-        medicine.addIngredient(ingredient);
-        medicine.addIngredient(Ingredient.of("ingredient2", "efficacy"));
-        medicine.addIngredient(Ingredient.of("ingredient3", "efficacy"));
+        medicine.addIngredient(ingredient, 1, "mg", "KP");
+        medicine.addIngredient(Ingredient.of("ingredient5", "efficacy"), 2, "mg", "KP");
+        medicine.addIngredient(Ingredient.of("ingredient6", "efficacy"), 3, "mg", "KP");
 
-        assertThat(medicine.getIngredients()).hasSize(3);
+        assertThat(medicine.getIngredients()).hasSize(6);
         assertThat(medicine.getIngredients())
                 .filteredOn(m -> m.getIngredient().equals(ingredient))
                 .isNotNull()
@@ -70,7 +86,7 @@ class MedicineTest {
 
         medicine.removeIngredient(ingredient);
 
-        assertThat(medicine.getIngredients()).hasSize(2);
+        assertThat(medicine.getIngredients()).hasSize(5);
         assertThat(medicine.getIngredients())
                 .filteredOn(m -> m.getIngredient().equals(ingredient))
                 .isEmpty();

--- a/BE/ytt/src/test/java/com/example/ytt/domain/medicine/domain/MedicineTest.java
+++ b/BE/ytt/src/test/java/com/example/ytt/domain/medicine/domain/MedicineTest.java
@@ -1,0 +1,79 @@
+package com.example.ytt.domain.medicine.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MedicineTest {
+
+    private Medicine medicine;
+
+    @BeforeEach
+    void setUp() {
+        medicine = Medicine.builder()
+                .name("name")
+                .productCode("productCode")
+                .manufacturer("manufacturer")
+                .efficacy("efficacy")
+                .usageInstructions("usageInstructions")
+                .precautions("precautions")
+                .sideEffects("sideEffects")
+                .price(1000)
+                .build();
+    }
+
+    @DisplayName("약 생성 테스트")
+    @Test
+    void createMedicine() {
+        assertThat(medicine).isNotNull();
+        assertThat(medicine.getName()).isEqualTo("name");
+        assertThat(medicine.getProductCode()).isEqualTo("productCode");
+        assertThat(medicine.getManufacturer()).isEqualTo("manufacturer");
+        assertThat(medicine.getEfficacy()).isEqualTo("efficacy");
+        assertThat(medicine.getUsageInstructions()).isEqualTo("usageInstructions");
+        assertThat(medicine.getPrecautions()).isEqualTo("precautions");
+        assertThat(medicine.getSideEffects()).isEqualTo("sideEffects");
+        assertThat(medicine.getPrice()).isEqualTo(1000);
+    }
+
+    @DisplayName("성분 추가")
+    @Test
+    void addIngredient() {
+        final Ingredient ingredient = Ingredient.of("ingredient", "efficacy");
+
+        medicine.addIngredient(ingredient);
+        medicine.addIngredient(ingredient);
+        medicine.addIngredient(ingredient);
+
+        assertThat(medicine.getIngredients())
+                .hasSize(3)
+                .extracting(v -> v.getIngredient().equals(ingredient))
+                .isNotNull();
+    }
+
+    @DisplayName("성분 삭제")
+    @Test
+    void removeIngredient() {
+        final Ingredient ingredient = Ingredient.of("ingredient", "efficacy");
+
+        medicine.addIngredient(ingredient);
+        medicine.addIngredient(Ingredient.of("ingredient2", "efficacy"));
+        medicine.addIngredient(Ingredient.of("ingredient3", "efficacy"));
+
+        assertThat(medicine.getIngredients()).hasSize(3);
+        assertThat(medicine.getIngredients())
+                .filteredOn(m -> m.getIngredient().equals(ingredient))
+                .isNotNull()
+                .hasSize(1);
+
+        medicine.removeIngredient(ingredient);
+
+        assertThat(medicine.getIngredients()).hasSize(2);
+        assertThat(medicine.getIngredients())
+                .filteredOn(m -> m.getIngredient().equals(ingredient))
+                .isEmpty();
+    }
+
+}

--- a/BE/ytt/src/test/java/com/example/ytt/domain/model/AddressTest.java
+++ b/BE/ytt/src/test/java/com/example/ytt/domain/model/AddressTest.java
@@ -44,7 +44,7 @@ class AddressTest {
     @DisplayName("Equals & HashCode 테스트")
     @Test
     void equalsAndHashCode() {
-        final Address newAddress = Address.from("address", location);
+        final Address newAddress = Address.of("address", location);
 
         System.out.println(address.hashCode());
 

--- a/BE/ytt/src/test/java/com/example/ytt/domain/vendingmachine/domain/VendingMachineTest.java
+++ b/BE/ytt/src/test/java/com/example/ytt/domain/vendingmachine/domain/VendingMachineTest.java
@@ -14,7 +14,7 @@ class VendingMachineTest {
 
     @BeforeEach
     void setUp() {
-         address = Address.from("address", 37.123456, 127.123456);
+         address = Address.of("address", 37.123456, 127.123456);
 
         vendingMachine = VendingMachine.builder()
                 .name("name")
@@ -45,7 +45,7 @@ class VendingMachineTest {
     @DisplayName("자판기 주소 수정 테스트")
     @Test
     void updateVendingMachineAddress() {
-        final Address newAddress = Address.from("new address", 37.654321, 127.654321);
+        final Address newAddress = Address.of("new address", 37.654321, 127.654321);
 
         vendingMachine.updateAddress(newAddress);
 

--- a/BE/ytt/src/test/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryTest.java
+++ b/BE/ytt/src/test/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryTest.java
@@ -24,7 +24,7 @@ class VendingMachineRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        address = Address.from("address", 37.305121, 127.922653);
+        address = Address.of("address", 37.305121, 127.922653);
         sevedVendingMachine = createAndSaveVendingMachine("vendingMachine", address);
     }
 
@@ -56,9 +56,9 @@ class VendingMachineRepositoryTest {
     @Test
     void findNearByLocation() {
         // 자판기 좌표는 대략적인 좌표로 주석의 거리는 정확하지 않음
-        createAndSaveVendingMachine("vendingMachine2", Address.from("address2", 37.307899, 127.920770)); // 약 500m
-        createAndSaveVendingMachine("vendingMachine3", Address.from("address3", 37.311945, 127.927402)); // 약 1000m
-        createAndSaveVendingMachine("vendingMachine4", Address.from("address4", 37.319237, 127.935006)); // 약 2500m
+        createAndSaveVendingMachine("vendingMachine2", Address.of("address2", 37.307899, 127.920770)); // 약 500m
+        createAndSaveVendingMachine("vendingMachine3", Address.of("address3", 37.311945, 127.927402)); // 약 1000m
+        createAndSaveVendingMachine("vendingMachine4", Address.of("address4", 37.319237, 127.935006)); // 약 2500m
 
         // sevedVendingMachine의 주소로 검색해 항상 1개의 자판기가 검색되어야 함
         assertThat(vendingMachineRepository.findNearByLocation(address.getLocation(), 0)).hasSize(1);

--- a/BE/ytt/src/test/java/com/example/ytt/domain/vendingmachine/service/VendingMachineFindServiceTest.java
+++ b/BE/ytt/src/test/java/com/example/ytt/domain/vendingmachine/service/VendingMachineFindServiceTest.java
@@ -33,10 +33,10 @@ class VendingMachineFindServiceTest {
     @BeforeEach
     void setUp() {
         vendingMachines = List.of(
-                createVendingMachine("강릉원주대 자판기1", Address.from("address1", 37.305121, 127.922653)),
-                createVendingMachine("강릉원주대 자판기2", Address.from("address2", 37.307899, 127.920770)),
-                createVendingMachine("강릉원주대 자판기3", Address.from("address3", 37.311945, 127.927402)),
-                createVendingMachine("강릉원주대 자판기4", Address.from("address4", 37.319237, 127.935006))
+                createVendingMachine("강릉원주대 자판기1", Address.of("address1", 37.305121, 127.922653)),
+                createVendingMachine("강릉원주대 자판기2", Address.of("address2", 37.307899, 127.920770)),
+                createVendingMachine("강릉원주대 자판기3", Address.of("address3", 37.311945, 127.927402)),
+                createVendingMachine("강릉원주대 자판기4", Address.of("address4", 37.319237, 127.935006))
         );
     }
 
@@ -101,7 +101,7 @@ class VendingMachineFindServiceTest {
         // then
         assertThat(vendingMachineDetailDto)
                 .isNotNull()
-                .isEqualTo(VendingMachineDetailDto.from(vendingMachine, false));
+                .isEqualTo(VendingMachineDetailDto.of(vendingMachine, false));
     }
 
     // vendingMachine 생성 메서드


### PR DESCRIPTION
## PR Type
<!-- PR 전 해당사항에 'x' 표시 ex) - [x] 기능 개발 -->
- [x] 기능 개발
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타: 

## 요약
약 entity 초기 버전 생성

## 상세 내용
- 식품의약품안전처_의약품개요정보(e약은요) API 기반 약 entity 생성
  - e약은요 기준 성분 정보, 유통 기한 알 수 없음
  - 의약품 제품 허가정보 API도 고려해야 함 (성분 정보, 유통 기한 등 포함)
    - 단, 특정 정보를 알기 위해선 추가적인 Data Parsing이 필요함 (효능, 사용법, 주의사항 등)

-> 의약품 제품 허가정보 기반 약 entity 생성
  
## Issue Number
<!-- 연관된 이슈는 #넘버, 해결된 이슈는 resolved #넘버 -->
#30, resolved #31 
