### PR TITLE
[FEAT] QueryDSL 적용 : BE

### DIFF
--- a/BE/ytt/build.gradle
+++ b/BE/ytt/build.gradle
@@ -52,6 +52,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	compileOnly 'org.projectlombok:lombok'
 
 	runtimeOnly 'com.h2database:h2'

--- a/BE/ytt/src/main/java/com/example/ytt/domain/inventory/repository/InventoryRepository.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/inventory/repository/InventoryRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface InventoryRepository extends JpaRepository<Inventory, Long> {
+public interface InventoryRepository extends JpaRepository<Inventory, Long>, InventoryRepositoryCustom {
 
     Optional<Inventory> findByMedicineIdAndVendingMachineId(Long medicineId, Long vendingMachineId); // 약품 ID와 자판기 ID로 검색 (특정 자판기에 특정 약품)
 

--- a/BE/ytt/src/main/java/com/example/ytt/domain/inventory/repository/InventoryRepository.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/inventory/repository/InventoryRepository.java
@@ -4,13 +4,8 @@ import com.example.ytt.domain.inventory.domain.Inventory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface InventoryRepository extends JpaRepository<Inventory, Long>, InventoryRepositoryCustom {
-
-    Optional<Inventory> findByMedicineIdAndVendingMachineId(Long medicineId, Long vendingMachineId); // 약품 ID와 자판기 ID로 검색 (특정 자판기에 특정 약품)
-
-    List<Inventory> findByVendingMachineId(Long vendingMachineId); // 자판기 ID로 검색 (특정 자판기의 재고 목록 조회)
 
     List<Inventory> findByMedicineId(Long medicineId); // 약품 ID로 검색 (특정 약품을 가지고 있는 재고 목록 (자판기) 조회)
 

--- a/BE/ytt/src/main/java/com/example/ytt/domain/inventory/repository/InventoryRepositoryCustom.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/inventory/repository/InventoryRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.example.ytt.domain.inventory.repository;
+
+import com.example.ytt.domain.inventory.domain.Inventory;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface InventoryRepositoryCustom {
+
+    List<Inventory> getInventories(Long vendingMachineId);
+
+    Optional<Inventory> getInventory(Long vendingMachineId, Long medicineId);
+
+}

--- a/BE/ytt/src/main/java/com/example/ytt/domain/inventory/repository/InventoryRepositoryImpl.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/inventory/repository/InventoryRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.example.ytt.domain.inventory.repository;
+
+import com.example.ytt.domain.inventory.domain.Inventory;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.example.ytt.domain.inventory.domain.QInventory.inventory;
+import static com.example.ytt.domain.medicine.domain.QIngredient.ingredient;
+import static com.example.ytt.domain.medicine.domain.QMedicine.medicine;
+import static com.example.ytt.domain.medicine.domain.QMedicineIngredient.medicineIngredient;
+import static com.example.ytt.domain.vendingmachine.domain.QVendingMachine.vendingMachine;
+
+@Repository
+@RequiredArgsConstructor
+public class InventoryRepositoryImpl implements InventoryRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Inventory> getInventories(Long vendingMachineId) {
+        return jpaQueryFactory
+                .selectFrom(inventory)
+                .join(inventory.vendingMachine, vendingMachine)
+                .join(inventory.medicine, medicine).fetchJoin()
+                .where(
+                        equalsVendingMachineId(vendingMachineId)
+                ).fetch();
+    }
+
+    @Override
+    public Optional<Inventory> getInventory(Long vendingMachineId, Long medicineId) {
+        Inventory inventory1 = jpaQueryFactory
+                .selectFrom(inventory)
+                .join(inventory.vendingMachine, vendingMachine)
+                .join(inventory.medicine, medicine).fetchJoin()
+                .join(medicine.ingredients, medicineIngredient).fetchJoin()
+                .join(medicineIngredient.ingredient, ingredient).fetchJoin()
+                .where(
+                        equalsVendingMachineId(vendingMachineId),
+                        equalsMedicineIdEq(medicineId)
+                ).fetchOne();
+
+        return Optional.ofNullable(inventory1);
+    }
+
+
+    // 자판기 ID 필터
+    private BooleanExpression equalsVendingMachineId(Long vendingMachineId) {
+        return vendingMachineId != null ? vendingMachine.id.eq(vendingMachineId) : null;
+    }
+
+    // 약품 ID 필터
+    private BooleanExpression equalsMedicineIdEq(Long medicineId) {
+        return medicineId != null ? medicine.id.eq(medicineId) : null;
+    }
+
+}

--- a/BE/ytt/src/main/java/com/example/ytt/domain/inventory/service/InboundService.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/inventory/service/InboundService.java
@@ -26,7 +26,7 @@ public class InboundService {
     // 약품 입고
     public MedicineDto inboundMedicine(InboundReqDto inboundReqDto) {
         Inventory inventory = inventoryRepository
-                .findByMedicineIdAndVendingMachineId(inboundReqDto.medicineId(), inboundReqDto.machineId())
+                .getInventory(inboundReqDto.medicineId(), inboundReqDto.machineId())
                 .orElseThrow(() -> new InboundException(ExceptionType.UNREGISTERED_INBOUND)); // 등록되지 않은 약의 입고는 불가. 자판기-약 등록과 입고를 분리하기 위함
 
         inventoryRepository.save(inventory.addQuantity(inboundReqDto.quantity())); // 수량 추가

--- a/BE/ytt/src/main/java/com/example/ytt/domain/inventory/service/InventoryService.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/inventory/service/InventoryService.java
@@ -21,7 +21,7 @@ public class InventoryService {
 
     // 자판기의 재고 목록 조회
     public List<MedicineDto> getMedicinesByVendingMachine(Long machineId) {
-        List<Inventory> list = inventoryRepository.findByVendingMachineId(machineId);
+        List<Inventory> list = inventoryRepository.getInventories(machineId);
 
         if (list.isEmpty()) {
             throw new InventoryException(ExceptionType.NO_CONTENT_INVENOTRY);
@@ -32,7 +32,7 @@ public class InventoryService {
 
     // 특정 자판기의 특정 약품 조회
     public MedicineDetailDto getMedicineByInventory(Long machineId, Long medicineId) {
-        Inventory inventory = inventoryRepository.findByMedicineIdAndVendingMachineId(machineId, medicineId).orElseThrow(() -> new InventoryException(ExceptionType.NOT_FOUND_INVENOTRY));
+        Inventory inventory = inventoryRepository.getInventory(machineId, medicineId).orElseThrow(() -> new InventoryException(ExceptionType.NOT_FOUND_INVENOTRY));
 
         return MedicineDetailDto.from(inventory);
     }

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/controller/MedicineController.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/controller/MedicineController.java
@@ -47,33 +47,52 @@ public class MedicineController {
     }
 
     @GetMapping("/name")
-    @SwaggerApi(summary = "이름으로 약품 조회", description = "이름에 포함되어 있는 약품 리스트 조회", implementation = ResponseDto.class)
+    @SwaggerApi(summary = "이름으로 약품 조회 (deprecated)", description = "이름에 포함되어 있는 약품 리스트 조회", implementation = ResponseDto.class)
     public ResponseEntity<ResponseDto<List<MedicineDto>>> getMedicinesByName(@RequestParam("name") String name) {
         return ResponseUtil.success(medicineFindService.getMedicinesByName(name));
     }
 
     @GetMapping("/manufacturer")
-    @SwaggerApi(summary = "제조사로 약품 조회", description = "제조사에 포함되어 있는 약품 리스트 조회", implementation = ResponseDto.class)
+    @SwaggerApi(summary = "제조사로 약품 조회 (deprecated)", description = "제조사에 포함되어 있는 약품 리스트 조회", implementation = ResponseDto.class)
     public ResponseEntity<ResponseDto<List<MedicineDto>>> getMedicinesByManufacturer(@RequestParam("manufacturer") String manufacturer) {
         return ResponseUtil.success(medicineFindService.getMedicinesByManufacturer(manufacturer));
     }
 
     @GetMapping("/ingredient")
-    @SwaggerApi(summary = "성분으로 약품 조회", description = "특정 성분이 포함된 약품 리스트 조회", implementation = ResponseDto.class)
+    @SwaggerApi(summary = "성분으로 약품 조회 (deprecated)", description = "특정 성분이 포함된 약품 리스트 조회", implementation = ResponseDto.class)
     public ResponseEntity<ResponseDto<List<MedicineDto>>> findMedicineByIngredientId(@RequestParam("ingredientId") Long ingredientId) {
         return ResponseUtil.success(medicineFindService.findMedicineByIngredientId(ingredientId));
     }
 
     @GetMapping("/{id}")
-    @SwaggerApi(summary = "약품 ID로 조회", description = "약품 ID로 약품 조회", implementation = ResponseDto.class)
+    @SwaggerApi(summary = "약품 ID로 조회 (deprecated)", description = "약품 ID로 약품 조회", implementation = ResponseDto.class)
     public ResponseEntity<ResponseDto<MedicineDetailDto>> getMedicineById(@PathVariable(value = "id") Long id) {
         return ResponseUtil.success(medicineFindService.getMedicineById(id));
     }
 
     @GetMapping("/productCode")
-    @SwaggerApi(summary = "약품 코드로 조회", description = "약품 코드로 약품 조회", implementation = ResponseDto.class)
+    @SwaggerApi(summary = "약품 코드로 조회 (deprecated)", description = "약품 코드로 약품 조회", implementation = ResponseDto.class)
     public ResponseEntity<ResponseDto<MedicineDetailDto>> getMedicineByProductCode(@RequestParam("productCode") String productCode) {
         return ResponseUtil.success(medicineFindService.getMedicinesByProductCode(productCode));
     }
 
+    /* -- QueryDSL을 사용한 코드 -- */
+    @GetMapping("/getByFilter")
+    @SwaggerApi(summary = "약품 기본 조회", description = "약품 리스트 조회", implementation = ResponseDto.class)
+    public ResponseEntity<ResponseDto<List<MedicineDto>>> getMedicines(
+            @RequestParam(value = "name", required = false)         String name,
+            @RequestParam(value = "manufacturer", required = false) String manufacturer,
+            @RequestParam(value = "ingredientId", required = false) Long ingredientId
+    ) {
+        return ResponseUtil.success(medicineFindService.getMedicines(name, manufacturer, ingredientId));
+    }
+
+    @GetMapping("/get")
+    @SwaggerApi(summary = "약품 상세 조회", description = "약품 상세 정보 조회 (id or productCode)", implementation = ResponseDto.class)
+    public ResponseEntity<ResponseDto<MedicineDetailDto>> getMedicineDetail(
+            @RequestParam(value = "medicineId", required = false) Long medicineId,
+            @RequestParam(value = "productCode", required = false) String productCode
+    ) {
+        return ResponseUtil.success(medicineFindService.getMedicineDetail(medicineId, productCode));
+    }
 }

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/controller/MedicineController.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/controller/MedicineController.java
@@ -80,11 +80,11 @@ public class MedicineController {
     @GetMapping("/getByFilter")
     @SwaggerApi(summary = "약품 기본 조회", description = "약품 리스트 조회", implementation = ResponseDto.class)
     public ResponseEntity<ResponseDto<List<MedicineDto>>> getMedicines(
-            @RequestParam(value = "name", required = false)         String name,
-            @RequestParam(value = "manufacturer", required = false) String manufacturer,
-            @RequestParam(value = "ingredientId", required = false) Long ingredientId
+            @RequestParam(value = "name", required = false)           String name,
+            @RequestParam(value = "manufacturer", required = false)   String manufacturer,
+            @RequestParam(value = "ingredientName", required = false) String ingredientName
     ) {
-        return ResponseUtil.success(medicineFindService.getMedicines(name, manufacturer, ingredientId));
+        return ResponseUtil.success(medicineFindService.getMedicines(name, manufacturer, ingredientName));
     }
 
     @GetMapping("/get")

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/dto/MedicineDto.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/dto/MedicineDto.java
@@ -23,16 +23,16 @@ public record MedicineDto(
         return new MedicineDto(medicine.getId(), medicine.getName(), medicine.getEfficacy(), medicine.getPrice(), stock, medicine.getImageURL());
     }
 
+    public static MedicineDto from(Medicine medicine) {
+        // description - 약의 효능을 설명으로
+        return of(medicine, 0);
+    }
+
     public static MedicineDto from(Inventory inventory) {
         return of(inventory.getMedicine(), inventory.getQuantity());
     }
 
     public static MedicineDto from(MedicineIngredient medicineIngredient) {
         return from(medicineIngredient.getMedicine());
-    }
-
-    public static MedicineDto from(Medicine medicine) {
-        // description - 약의 효능을 설명으로
-        return new MedicineDto(medicine.getId(), medicine.getName(), medicine.getEfficacy(), medicine.getPrice(), 0, medicine.getImageURL());
     }
 }

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/repository/MedicineRepository.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/repository/MedicineRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface MedicineRepository extends JpaRepository<Medicine, Long> {
+public interface MedicineRepository extends JpaRepository<Medicine, Long>, MedicineRepositoryCustom {
 
     Optional<Medicine> findByProductCode(String productCode);
 

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/repository/MedicineRepositoryCustom.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/repository/MedicineRepositoryCustom.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 public interface MedicineRepositoryCustom {
 
-    List<Medicine> getMedicines(String name, String manufacturer, Long ingredientId);
+    List<Medicine> getMedicines(String name, String manufacturer, String ingredientName);
 
     Optional<Medicine> getMedicineDetail(Long medicineId, String poductCode);
 

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/repository/MedicineRepositoryCustom.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/repository/MedicineRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.example.ytt.domain.medicine.repository;
+
+import com.example.ytt.domain.medicine.domain.Medicine;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MedicineRepositoryCustom {
+
+    List<Medicine> getMedicines(String name, String manufacturer, Long ingredientId);
+
+    Optional<Medicine> getMedicineDetail(Long medicineId, String poductCode);
+
+}

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/repository/MedicineRepositoryImpl.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/repository/MedicineRepositoryImpl.java
@@ -20,7 +20,7 @@ public class MedicineRepositoryImpl implements MedicineRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<Medicine> getMedicines(String name, String manufacturer, Long ingredientId) {
+    public List<Medicine> getMedicines(String name, String manufacturer, String ingredientName) {
         return jpaQueryFactory
                 .selectFrom(medicine)
                 .leftJoin(medicine.ingredients, medicineIngredient)
@@ -28,7 +28,7 @@ public class MedicineRepositoryImpl implements MedicineRepositoryCustom {
                 .where(
                         nameContains(name),
                         manufacturerContains(manufacturer),
-                        ingredientContains(ingredientId)
+                        ingredientContains(ingredientName)
                 )
                 .fetch();
     }
@@ -56,8 +56,8 @@ public class MedicineRepositoryImpl implements MedicineRepositoryCustom {
         return manufacturer != null ? medicine.manufacturer.contains(manufacturer) : null;
     }
 
-    private BooleanExpression ingredientContains(Long ingredientId) {
-        return ingredientId != null ? medicine.ingredients.any().ingredient.id.eq(ingredientId) : null;
+    private BooleanExpression ingredientContains(String ingredientName) {
+        return ingredientName != null ? medicine.ingredients.any().ingredient.name.contains(ingredientName) : null;
     }
 
     private BooleanExpression equalsMedicineId(Long medicineId) {

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/repository/MedicineRepositoryImpl.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/repository/MedicineRepositoryImpl.java
@@ -1,0 +1,72 @@
+package com.example.ytt.domain.medicine.repository;
+
+import com.example.ytt.domain.medicine.domain.Medicine;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.example.ytt.domain.medicine.domain.QIngredient.ingredient;
+import static com.example.ytt.domain.medicine.domain.QMedicine.medicine;
+import static com.example.ytt.domain.medicine.domain.QMedicineIngredient.medicineIngredient;
+
+@Repository
+@RequiredArgsConstructor
+public class MedicineRepositoryImpl implements MedicineRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Medicine> getMedicines(String name, String manufacturer, Long ingredientId) {
+        return jpaQueryFactory
+                .selectFrom(medicine)
+                .leftJoin(medicine.ingredients, medicineIngredient)
+                .leftJoin(medicineIngredient.ingredient, ingredient)
+                .where(
+                        nameContains(name),
+                        manufacturerContains(manufacturer),
+                        ingredientContains(ingredientId)
+                )
+                .fetch();
+    }
+
+    @Override
+    public Optional<Medicine> getMedicineDetail(Long medicineId, String poductCode) {
+        Medicine tMedicine = jpaQueryFactory
+                .selectFrom(medicine)
+                .leftJoin(medicine.ingredients, medicineIngredient).fetchJoin()
+                .leftJoin(medicineIngredient.ingredient, ingredient).fetchJoin()
+                .where(
+                        equalsMedicineId(medicineId),
+                        equalsProductCode(poductCode)
+                )
+                .fetchOne();
+
+        return Optional.ofNullable(tMedicine);
+    }
+
+    private BooleanExpression nameContains(String name) {
+        return name != null ? medicine.name.contains(name) : null;
+    }
+
+    private BooleanExpression manufacturerContains(String manufacturer) {
+        return manufacturer != null ? medicine.manufacturer.contains(manufacturer) : null;
+    }
+
+    private BooleanExpression ingredientContains(Long ingredientId) {
+        return ingredientId != null ? medicine.ingredients.any().ingredient.id.eq(ingredientId) : null;
+    }
+
+    private BooleanExpression equalsMedicineId(Long medicineId) {
+        return medicineId != null ? medicine.id.eq(medicineId) : null;
+    }
+
+    private BooleanExpression equalsProductCode(String productCode) {
+        return productCode != null ? medicine.productCode.eq(productCode) : null;
+    }
+
+
+}

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/service/MedicineFindService.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/service/MedicineFindService.java
@@ -106,8 +106,8 @@ public class MedicineFindService {
 
     /* -- QueryDSL을 사용한 코드 -- */
 
-    public List<MedicineDto> getMedicines(String name, String manufacturer, Long ingredientId) {
-        List<Medicine> list = medicineRepository.getMedicines(name, manufacturer, ingredientId);
+    public List<MedicineDto> getMedicines(String name, String manufacturer, String ingredientName) {
+        List<Medicine> list = medicineRepository.getMedicines(name, manufacturer, ingredientName);
 
         if (list.isEmpty()) {
             throw new MedicineException(ExceptionType.NO_CONTENT_MEDICINE);

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/service/MedicineFindService.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/service/MedicineFindService.java
@@ -117,6 +117,10 @@ public class MedicineFindService {
     }
 
     public MedicineDetailDto getMedicineDetail(Long medicineId, String productCode) {
+        if (medicineId == null && productCode == null) {
+            throw new MedicineException(ExceptionType.BAD_REQUEST_MEDICINE_SEARCH);
+        }
+
         Medicine medicine = medicineRepository.getMedicineDetail(medicineId, productCode).orElseThrow(() -> new MedicineException(ExceptionType.NOT_FOUND_MEDICINE));
 
         return MedicineDetailDto.from(medicine);

--- a/BE/ytt/src/main/java/com/example/ytt/domain/medicine/service/MedicineFindService.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/medicine/service/MedicineFindService.java
@@ -35,6 +35,10 @@ public class MedicineFindService {
         return list.stream().map(MedicineDto::from).toList();
     }
 
+    /**
+     * @deprecated 추후 QueryDSL로 구현한 코드로 대체 예정
+     */
+    @Deprecated(since="", forRemoval=true)
     public List<MedicineDto> getMedicinesByName(String name) {
         List<Medicine> list = medicineRepository.findByNameContaining(name);
 
@@ -45,6 +49,10 @@ public class MedicineFindService {
         return list.stream().map(MedicineDto::from).toList();
     }
 
+    /**
+     * @deprecated 추후 QueryDSL로 구현한 코드로 대체 예정
+     */
+    @Deprecated(since="", forRemoval=true)
     public List<MedicineDto> getMedicinesByManufacturer(String manufacturer) {
         List<Medicine> list = medicineRepository.findByManufacturer(manufacturer);
 
@@ -56,6 +64,10 @@ public class MedicineFindService {
     }
 
     // 특정 성분이 포함된 약품 목록 조회 (성분 ID로 검색)
+    /**
+     * @deprecated 추후 QueryDSL로 구현한 코드로 대체 예정
+     */
+    @Deprecated(since="", forRemoval=true)
     public List<MedicineDto> findMedicineByIngredientId(Long ingredientId) {
         if (!ingredientRepository.existsById(ingredientId)) {
             throw new IngredientException(ExceptionType.NOT_FOUND_INGREDIENT); // Ingredient가 존재하는 지 확인
@@ -72,14 +84,40 @@ public class MedicineFindService {
 
     // MedicineDetailDto 조회
 
+    /**
+     * @deprecated 추후 QueryDSL로 구현한 코드로 대체 예정
+     */
+    @Deprecated(since="", forRemoval=true)
     public MedicineDetailDto getMedicineById(Long id) {
         Medicine medicine = medicineRepository.findById(id).orElseThrow(() -> new MedicineException(ExceptionType.NOT_FOUND_MEDICINE));
 
         return MedicineDetailDto.from(medicine);
     }
 
+    /**
+     * @deprecated 추후 QueryDSL로 구현한 코드로 대체 예정
+     */
+    @Deprecated(since="", forRemoval=true)
     public MedicineDetailDto getMedicinesByProductCode(String productCode) {
         Medicine medicine = medicineRepository.findByProductCode(productCode).orElseThrow(() -> new MedicineException(ExceptionType.NOT_FOUND_MEDICINE));
+
+        return MedicineDetailDto.from(medicine);
+    }
+
+    /* -- QueryDSL을 사용한 코드 -- */
+
+    public List<MedicineDto> getMedicines(String name, String manufacturer, Long ingredientId) {
+        List<Medicine> list = medicineRepository.getMedicines(name, manufacturer, ingredientId);
+
+        if (list.isEmpty()) {
+            throw new MedicineException(ExceptionType.NO_CONTENT_MEDICINE);
+        }
+
+        return list.stream().map(MedicineDto::from).toList();
+    }
+
+    public MedicineDetailDto getMedicineDetail(Long medicineId, String productCode) {
+        Medicine medicine = medicineRepository.getMedicineDetail(medicineId, productCode).orElseThrow(() -> new MedicineException(ExceptionType.NOT_FOUND_MEDICINE));
 
         return MedicineDetailDto.from(medicine);
     }

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/controller/VendingMachineFindController.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/controller/VendingMachineFindController.java
@@ -41,32 +41,28 @@ public class VendingMachineFindController {
     }
 
     @GetMapping("/name")
-    @SwaggerApi(summary = "이름으로 자판기 조회", description = "이름에 포함되어 있는 자판기 리스트 조회", implementation = ResponseDto.class)
+    @SwaggerApi(summary = "이름으로 자판기 조회 (deprecated)", description = "이름에 포함되어 있는 자판기 리스트 조회", implementation = ResponseDto.class)
     public ResponseEntity<ResponseDto<List<VendingMachineDto>>> getVendingMachinesByName(@Parameter(description = "자판기 이름", example = "강릉원주대 자판기") @RequestParam("name") String name) {
         return ResponseUtil.success(vendingMachineFindService.getVendingMachinesByName(name));
     }
 
     @GetMapping("/medicine")
-    @SwaggerApi(summary = "약품으로 자판기 조회", description = "약품이 포함되어 있는 자판기 리스트 조회", implementation = ResponseDto.class)
+    @SwaggerApi(summary = "약품으로 자판기 조회 (deprecated)", description = "약품이 포함되어 있는 자판기 리스트 조회", implementation = ResponseDto.class)
     public ResponseEntity<ResponseDto<List<VendingMachineDto>>> getVendingMachinesByMedicine(@RequestParam("medicine_id") Long medicineId) {
         return ResponseUtil.success(vendingMachineFindService.getVendingMachinesByMedicine(medicineId));
     }
 
     @GetMapping("/nearby")
-    @SwaggerApi(summary = "주변 자판기 조회", description = "주어진 값으로부터 반경 2.5km 내 자판기 리스트 조회", implementation = ResponseDto.class)
+    @SwaggerApi(summary = "주변 자판기 조회 (deprecated)", description = "주어진 값으로부터 반경 2.5km 내 자판기 리스트 조회", implementation = ResponseDto.class)
     public ResponseEntity<ResponseDto<List<VendingMachineDto>>> getVendingMachinesNearByLocation(
             @Parameter(description = "자판기의 위도", example = "37.305121")
             @RequestParam("latitude") Double latitude,
             @Parameter(description = "자판기의 경도", example = "127.922653")
             @RequestParam("longitude") Double longitude) {
-
-        // TODO: 거리 파라미터 추가할지, 기본값 설정할지 고민 필요
-        // TODO: 위도, 경도 범위 제한 추가할지 고민 필요
-
         return ResponseUtil.success(vendingMachineFindService.getVendingMachinesNearByLocation(latitude, longitude, 2500.0));
     }
 
-    // 자판기 상세 조회
+    /* -- 자판기 상세 조회 -- */
 
     @GetMapping("/{id}")
     @SwaggerApi(summary = "자판기 ID로 조회", description = "자판기 ID로 자판기 조회", implementation = ResponseDto.class)
@@ -84,6 +80,30 @@ public class VendingMachineFindController {
     @SwaggerApi(summary = "특정 자판기의 특정 약 조회", description = "자판기의 특정 약 상세 조회", implementation = ResponseDto.class)
     public ResponseEntity<ResponseDto<MedicineDetailDto>> getVendingMachineById(@PathVariable(value = "id") Long machineId, @RequestParam("medicineId") Long medicineId) {
         return ResponseUtil.success(inventoryService.getMedicineByInventory(machineId, medicineId));
+    }
+
+    /* -- QueryDSL을 사용한 코드 -- */
+
+    @GetMapping("/getVendingMachines")
+    @SwaggerApi(summary = "자판기 기본 조회", description = "일정 범위 내에 자판기 리스트 조회", implementation = ResponseDto.class)
+    public ResponseEntity<ResponseDto<List<VendingMachineDto>>> getVendingMachines(
+            @RequestParam(value = "latitude", required = true)                           Double latitude,
+            @RequestParam(value = "longitude", required = true)                          Double longitude,
+            @RequestParam(value = "distance", required = false, defaultValue = "2500.0") Double distance,
+            @RequestParam(value = "name", required = false)                              String name
+    ) {
+        return ResponseUtil.success(vendingMachineFindService.getVendingMachines(latitude, longitude, distance, name));
+    }
+
+    @GetMapping("/getVendingMachinesByMedicine")
+    @SwaggerApi(summary = "약품으로 자판기 조회", description = "약품이 포함되어 있는 자판기 리스트 조회", implementation = ResponseDto.class)
+    public ResponseEntity<ResponseDto<List<VendingMachineDto>>> getVendingMachinesByMedicine(
+            @RequestParam(value = "latitude", required = false)                          Double latitude,
+            @RequestParam(value = "longitude", required = false)                         Double longitude,
+            @RequestParam(value = "distance", required = false, defaultValue = "2500.0") Double distance,
+            @RequestParam(value = "medicine_id", required = true)                        Long medicineId
+    ) {
+        return ResponseUtil.success(vendingMachineFindService.getVendingMachinesByMedicine(latitude, longitude, distance, medicineId));
     }
 
 }

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/controller/VendingMachineFindController.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/controller/VendingMachineFindController.java
@@ -84,7 +84,7 @@ public class VendingMachineFindController {
 
     /* -- QueryDSL을 사용한 코드 -- */
 
-    @GetMapping("/getVendingMachines")
+    @GetMapping("/get")
     @SwaggerApi(summary = "자판기 기본 조회", description = "일정 범위 내에 자판기 리스트 조회", implementation = ResponseDto.class)
     public ResponseEntity<ResponseDto<List<VendingMachineDto>>> getVendingMachines(
             @RequestParam(value = "latitude", required = true)                           Double latitude,
@@ -95,7 +95,7 @@ public class VendingMachineFindController {
         return ResponseUtil.success(vendingMachineFindService.getVendingMachines(latitude, longitude, distance, name));
     }
 
-    @GetMapping("/getVendingMachinesByMedicine")
+    @GetMapping("/getByMedicine")
     @SwaggerApi(summary = "약품으로 자판기 조회", description = "약품이 포함되어 있는 자판기 리스트 조회", implementation = ResponseDto.class)
     public ResponseEntity<ResponseDto<List<VendingMachineDto>>> getVendingMachinesByMedicine(
             @RequestParam(value = "latitude", required = false)                          Double latitude,
@@ -105,5 +105,13 @@ public class VendingMachineFindController {
     ) {
         return ResponseUtil.success(vendingMachineFindService.getVendingMachinesByMedicine(latitude, longitude, distance, medicineId));
     }
+
+    @GetMapping("/getFavorites")
+    @SwaggerApi(summary = "즐겨찾기 자판기 조회", description = "즐겨찾기한 자판기 리스트 조회", implementation = ResponseDto.class)
+    public ResponseEntity<ResponseDto<List<VendingMachineDto>>> getFavoriteVendingMachines(@AuthenticationPrincipal CustomUserDetails user) {
+        return ResponseUtil.success(vendingMachineFindService.getFavoriteVendingMachines(user.getId()));
+    }
+
+
 
 }

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/controller/VendingMachineFindController.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/controller/VendingMachineFindController.java
@@ -62,26 +62,6 @@ public class VendingMachineFindController {
         return ResponseUtil.success(vendingMachineFindService.getVendingMachinesNearByLocation(latitude, longitude, 2500.0));
     }
 
-    /* -- 자판기 상세 조회 -- */
-
-    @GetMapping("/{id}")
-    @SwaggerApi(summary = "자판기 ID로 조회", description = "자판기 ID로 자판기 조회", implementation = ResponseDto.class)
-    public  ResponseEntity<ResponseDto<VendingMachineDetailDto>> getVendingMachineById(@PathVariable(value = "id") Long machineId, @AuthenticationPrincipal CustomUserDetails user) {
-        return ResponseUtil.success(vendingMachineFindService.getVendingMachineDetail(machineId, user.getId()));
-    }
-
-    @GetMapping("/{id}/medicines")
-    @SwaggerApi(summary = "특정 자판기의 전체 재고 조회", description = "자판기 ID로 자판기의 재고 조회", implementation = ResponseDto.class)
-    public ResponseEntity<ResponseDto<List<MedicineDto>>> getVendingMachineInventory(@PathVariable(value = "id") Long id) {
-        return ResponseUtil.success(inventoryService.getMedicinesByVendingMachine(id));
-    }
-
-    @GetMapping("/{id}/medicine")
-    @SwaggerApi(summary = "특정 자판기의 특정 약 조회", description = "자판기의 특정 약 상세 조회", implementation = ResponseDto.class)
-    public ResponseEntity<ResponseDto<MedicineDetailDto>> getVendingMachineById(@PathVariable(value = "id") Long machineId, @RequestParam("medicineId") Long medicineId) {
-        return ResponseUtil.success(inventoryService.getMedicineByInventory(machineId, medicineId));
-    }
-
     /* -- QueryDSL을 사용한 코드 -- */
 
     @GetMapping("/get")
@@ -112,6 +92,24 @@ public class VendingMachineFindController {
         return ResponseUtil.success(vendingMachineFindService.getFavoriteVendingMachines(user.getId()));
     }
 
+    /* -- 자판기 상세 조회 -- */
 
+    @GetMapping("/{id}")
+    @SwaggerApi(summary = "자판기 ID로 조회", description = "자판기 ID로 자판기 조회", implementation = ResponseDto.class)
+    public  ResponseEntity<ResponseDto<VendingMachineDetailDto>> getVendingMachineById(@PathVariable(value = "id") Long machineId, @AuthenticationPrincipal CustomUserDetails user) {
+        return ResponseUtil.success(vendingMachineFindService.getVendingMachineDetail(machineId, user.getId()));
+    }
+
+    @GetMapping("/{id}/medicines")
+    @SwaggerApi(summary = "특정 자판기의 전체 재고 조회", description = "자판기 ID로 자판기의 재고 조회", implementation = ResponseDto.class)
+    public ResponseEntity<ResponseDto<List<MedicineDto>>> getMedicinesInVendingMachine(@PathVariable(value = "id") Long id) {
+        return ResponseUtil.success(inventoryService.getMedicinesByVendingMachine(id));
+    }
+
+    @GetMapping("/{id}/medicine")
+    @SwaggerApi(summary = "특정 자판기의 특정 약 조회", description = "자판기의 특정 약 상세 조회", implementation = ResponseDto.class)
+    public ResponseEntity<ResponseDto<MedicineDetailDto>> getMedicineInVendingMachine(@PathVariable(value = "id") Long machineId, @RequestParam("medicineId") Long medicineId) {
+        return ResponseUtil.success(inventoryService.getMedicineByInventory(machineId, medicineId));
+    }
 
 }

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepository.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface VendingMachineRepository extends JpaRepository<VendingMachine, Long> {
+public interface VendingMachineRepository extends JpaRepository<VendingMachine, Long>, VendingMachineRepositoryCustom {
     List<VendingMachine> findByNameContaining(String name);
 
 //    ST_DISTANCE_SPHERE 미지원으로 인해 ST_DISTANCE ST_TRANSFORM(3857, 단위를 1m로)으로 구현

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryCustom.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryCustom.java
@@ -12,6 +12,8 @@ public interface VendingMachineRepositoryCustom {
 
     List<VendingMachine> getVendingMachinesByMedicine(Point location, double distance, Long medicineId);
 
-    Optional<VendingMachine> getVendingMachineDetails(Long vendingMachineId);
+    List<VendingMachine> getFavoriteVendingMachines(Long userId);
+
+    Optional<VendingMachine> getVendingMachineDetail(Long vendingMachineId);
 
 }

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryCustom.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryCustom.java
@@ -4,11 +4,14 @@ import com.example.ytt.domain.vendingmachine.domain.VendingMachine;
 import org.locationtech.jts.geom.Point;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface VendingMachineRepositoryCustom {
 
     List<VendingMachine> getVendingMachines(Point location, double distance, String name);
 
     List<VendingMachine> getVendingMachinesByMedicine(Point location, double distance, Long medicineId);
+
+    Optional<VendingMachine> getVendingMachineDetails(Long vendingMachineId);
 
 }

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryCustom.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.example.ytt.domain.vendingmachine.repository;
+
+import com.example.ytt.domain.vendingmachine.domain.VendingMachine;
+import org.locationtech.jts.geom.Point;
+
+import java.util.List;
+
+public interface VendingMachineRepositoryCustom {
+
+    List<VendingMachine> getVendingMachines(Point location, double distance, String name);
+
+    List<VendingMachine> getVendingMachinesByMedicine(Point location, double distance, Long medicineId);
+
+}

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryImpl.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryImpl.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 
 import static com.example.ytt.domain.inventory.domain.QInventory.inventory;
 import static com.example.ytt.domain.medicine.domain.QMedicine.medicine;
+import static com.example.ytt.domain.user.domain.QUser.user;
+import static com.example.ytt.domain.vendingmachine.domain.QFavorite.favorite;
 import static com.example.ytt.domain.vendingmachine.domain.QVendingMachine.vendingMachine;
 
 @Repository
@@ -26,8 +28,6 @@ public class VendingMachineRepositoryImpl implements VendingMachineRepositoryCus
     public List<VendingMachine> getVendingMachines(Point location, double distance, String name) {
         return jpaQueryFactory
                 .selectFrom(vendingMachine)
-                .leftJoin(vendingMachine.inventories, inventory)
-                .leftJoin(inventory.medicine, medicine)
                 .where(
                         distanceLessThan(location, distance),
                         nameContains(name)
@@ -39,8 +39,8 @@ public class VendingMachineRepositoryImpl implements VendingMachineRepositoryCus
     public List<VendingMachine> getVendingMachinesByMedicine(Point location, double distance, Long medicineId) {
         return jpaQueryFactory
                 .selectFrom(vendingMachine)
-                .leftJoin(vendingMachine.inventories, inventory)
-                .leftJoin(inventory.medicine, medicine)
+                .join(inventory).on(vendingMachine.id.eq(inventory.vendingMachine.id))
+                .join(inventory.medicine, medicine)
                 .where(
                         distanceLessThan(location, distance),
                         medicineContains(medicineId)
@@ -48,8 +48,19 @@ public class VendingMachineRepositoryImpl implements VendingMachineRepositoryCus
                 .fetch();
     }
 
+    // 즐겨찾기는 즐겨찾기 생성 후 테스트
     @Override
-    public Optional<VendingMachine> getVendingMachineDetails(Long vendingMachineId) {
+    public List<VendingMachine> getFavoriteVendingMachines(Long userId) {
+        return jpaQueryFactory
+                .selectFrom(vendingMachine)
+                .join(favorite).on(vendingMachine.id.eq(favorite.vendingMachine.id))
+                .join(favorite.user, user)
+                .where(favorite.user.id.eq(userId))
+                .fetch();
+    }
+
+    @Override
+    public Optional<VendingMachine> getVendingMachineDetail(Long vendingMachineId) {
         VendingMachine vendingmachine = jpaQueryFactory
                 .selectFrom(vendingMachine)
                 .leftJoin(vendingMachine.inventories, inventory).fetchJoin()

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryImpl.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryImpl.java
@@ -48,6 +48,19 @@ public class VendingMachineRepositoryImpl implements VendingMachineRepositoryCus
                 .fetch();
     }
 
+    @Override
+    public Optional<VendingMachine> getVendingMachineDetails(Long vendingMachineId) {
+        VendingMachine vendingmachine = jpaQueryFactory
+                .selectFrom(vendingMachine)
+                .leftJoin(vendingMachine.inventories, inventory).fetchJoin()
+                .leftJoin(inventory.medicine, medicine).fetchJoin()
+                .where(vendingMachine.id.eq(vendingMachineId))
+                .fetchOne();
+
+        return Optional.ofNullable(vendingmachine);
+    }
+
+
     // 자판기 이름 필터
     private BooleanExpression nameContains(String name) {
         return name == null ? null : vendingMachine.name.contains(name);

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryImpl.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/repository/VendingMachineRepositoryImpl.java
@@ -1,0 +1,75 @@
+package com.example.ytt.domain.vendingmachine.repository;
+
+import com.example.ytt.domain.vendingmachine.domain.VendingMachine;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Point;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.example.ytt.domain.inventory.domain.QInventory.inventory;
+import static com.example.ytt.domain.medicine.domain.QMedicine.medicine;
+import static com.example.ytt.domain.vendingmachine.domain.QVendingMachine.vendingMachine;
+
+@Repository
+@RequiredArgsConstructor
+public class VendingMachineRepositoryImpl implements VendingMachineRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<VendingMachine> getVendingMachines(Point location, double distance, String name) {
+        return jpaQueryFactory
+                .selectFrom(vendingMachine)
+                .leftJoin(vendingMachine.inventories, inventory)
+                .leftJoin(inventory.medicine, medicine)
+                .where(
+                        distanceLessThan(location, distance),
+                        nameContains(name)
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<VendingMachine> getVendingMachinesByMedicine(Point location, double distance, Long medicineId) {
+        return jpaQueryFactory
+                .selectFrom(vendingMachine)
+                .leftJoin(vendingMachine.inventories, inventory)
+                .leftJoin(inventory.medicine, medicine)
+                .where(
+                        distanceLessThan(location, distance),
+                        medicineContains(medicineId)
+                )
+                .fetch();
+    }
+
+    // 자판기 이름 필터
+    private BooleanExpression nameContains(String name) {
+        return name == null ? null : vendingMachine.name.contains(name);
+    }
+
+    // 자판기 검색 범위 필터
+    private BooleanExpression distanceLessThan(Point location, Double distance) {
+        if (location == null || distance == null) {
+            return null;
+        }
+
+        // 공간 거리 표현식 정의
+        NumberTemplate<Double> distanceExpression = Expressions.numberTemplate(Double.class,
+                "ST_DISTANCE(ST_TRANSFORM({0}, 3857), ST_TRANSFORM({1}, 3857))",
+                vendingMachine.address.location, location);
+
+        return distanceExpression.loe(distance);
+    }
+
+    // 특정 약을 포함하는 자판기 리스트 필터
+    private BooleanExpression medicineContains(Long medicineId) {
+        return medicineId == null ? null : inventory.medicine.id.eq(medicineId);
+    }
+
+}

--- a/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/service/VendingMachineFindService.java
+++ b/BE/ytt/src/main/java/com/example/ytt/domain/vendingmachine/service/VendingMachineFindService.java
@@ -109,8 +109,18 @@ public class VendingMachineFindService {
         return list.stream().map(VendingMachineDto::from).toList();
     }
 
+    public List<VendingMachineDto> getFavoriteVendingMachines(Long userId) {
+        List<VendingMachine> list = vendingMachineRepository.getFavoriteVendingMachines(userId);
+
+        if (list.isEmpty()) {
+            throw new VendingMachineException(ExceptionType.NO_CONTENT_VENDING_MACHINE);
+        }
+
+        return list.stream().map(VendingMachineDto::from).toList();
+    }
+
     public VendingMachineDetailDto getVendingMachineDetail(Long machineId, Long userId) {
-        VendingMachine vendingMachine = vendingMachineRepository.getVendingMachineDetails(machineId).orElseThrow(() -> new VendingMachineException(ExceptionType.NOT_FOUND_VENDING_MACHINE));
+        VendingMachine vendingMachine = vendingMachineRepository.getVendingMachineDetail(machineId).orElseThrow(() -> new VendingMachineException(ExceptionType.NOT_FOUND_VENDING_MACHINE));
 
         return convertToVendingMachineDetailDto(vendingMachine, userId);
     }

--- a/BE/ytt/src/main/java/com/example/ytt/global/config/QueryDslConfig.java
+++ b/BE/ytt/src/main/java/com/example/ytt/global/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.example.ytt.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/BE/ytt/src/main/java/com/example/ytt/global/error/code/ExceptionType.java
+++ b/BE/ytt/src/main/java/com/example/ytt/global/error/code/ExceptionType.java
@@ -46,15 +46,18 @@ public enum ExceptionType {
     // 자판기 에러
     NOT_FOUND_VENDING_MACHINE(700, HttpStatus.NOT_FOUND, "자판기 정보가 없습니다."), // 404 Not Found
     NO_CONTENT_VENDING_MACHINE(701, HttpStatus.NO_CONTENT, "자판기 정보가 없습니다."), // 204 No Content
-    ALREADY_EXIST_LOCATION(702, HttpStatus.CONFLICT, "이미 존재하는 위치입니다."), // 409 Conflict, 아직 사용X
+
+    ALREADY_EXIST_LOCATION(710, HttpStatus.CONFLICT, "이미 존재하는 위치입니다."), // 409 Conflict, 아직 사용X
 
     // 약 에러
     NOT_FOUND_MEDICINE(800, HttpStatus.NOT_FOUND, "약 정보가 없습니다."), // 404 Not Found
-    NO_CONTENT_MEDICINE(801, HttpStatus.NO_CONTENT, "약 정보가 없습니다."), // 204 No Content
-    ALREADY_EXIST_MEDICINE(802, HttpStatus.CONFLICT, "이미 등록된 약입니다."), // 409 Conflict
-    NOT_FOUND_MEDICINE_REGISTER(810, HttpStatus.NOT_FOUND, "약 등록 정보가 없습니다."), // 404 Not Found
-    NO_CONTENT_MEDICINE_REGISTER(811, HttpStatus.NO_CONTENT, "약 등록 정보가 없습니다."), // 204 No Content
-    ALREADY_EXIST_MEDICINE_REGISTER(812, HttpStatus.CONFLICT, "이미 등록된 약입니다."), // 409 Conflict
+    NO_CONTENT_MEDICINE(801, HttpStatus.NO_CONTENT, "조건에 맞는 약 정보가 없습니다."), // 204 No Content
+    BAD_REQUEST_MEDICINE_SEARCH(802, HttpStatus.BAD_REQUEST, "약 ID 또는 약품 코드를 입력해주세요"), // 400 Bad Request
+
+    ALREADY_EXIST_MEDICINE(810, HttpStatus.CONFLICT, "이미 등록된 약입니다."), // 409 Conflict
+    NOT_FOUND_MEDICINE_REGISTER(811, HttpStatus.NOT_FOUND, "약 등록 정보가 없습니다."), // 404 Not Found
+    NO_CONTENT_MEDICINE_REGISTER(812, HttpStatus.NO_CONTENT, "약 등록 정보가 없습니다."), // 204 No Content
+    ALREADY_EXIST_MEDICINE_REGISTER(813, HttpStatus.CONFLICT, "이미 등록된 약입니다."), // 409 Conflict
 
     // 약 성분 에러
     NOT_FOUND_INGREDIENT(900, HttpStatus.NOT_FOUND, "약 성분 정보가 없습니다."), // 404 Not Found
@@ -65,6 +68,7 @@ public enum ExceptionType {
     NOT_FOUND_INBOUND_LOG(1000, HttpStatus.NOT_FOUND, "입고 정보가 없습니다."), // 404 Not Found
     NO_CONTENT_INBOUND_LOG(1001, HttpStatus.NO_CONTENT, "입고 정보가 없습니다."), // 204 No Content
     UNREGISTERED_INBOUND(1002, HttpStatus.BAD_REQUEST, "등록되지 않은 약의 입고는 불가합니다."), // 400 Bad Request
+
     NOT_FOUND_INVENOTRY(1010, HttpStatus.NOT_FOUND, "재고 정보가 없습니다."), // 404 Not Found
     NO_CONTENT_INVENOTRY(1011, HttpStatus.NO_CONTENT, "재고 정보가 없습니다."), // 204 No Content
 


### PR DESCRIPTION
## PR Type
<!-- PR 전 해당사항에 'x' 표시 ex) - [x] 기능 개발 -->
- [x] 기능 개발
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타: 

## 요약
QueryDSL 적용 및 기존 조회 코드 수정

## 상세 내용
- 자판기, 약 조회 시 발생하는 N+1 문제를 해결
- 기존 조회 방식을 QueryDSL을 통해 한 번에 필터링할 수 있게 수정
  - 자판기 : 이름, 제조사, 거리 등 조회를 따로 메서드로 구헌한 방식에서 하나의 메서드에서 필터링 하는 방식으로 수정
  - 약 : 이름, 성분 등 위와 동일
- 기존 조회 코드는 FE와의 통신을 위해 유지 

## 추가사항
- FE에서 기존 API에서 수정된 API로 변경 시 이전 코드 삭제할 것

## Issue Number
<!-- 연관된 이슈는 #넘버, 해결된 이슈는 resolved #넘버 -->
> resolved #85
